### PR TITLE
Add issue 8 student session page

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 ## Front End Prototype
 
-Issue #9 has a runnable React + Tailwind student question form in `front-end`.
+Issue #9 added the React + Tailwind frontend starter, and Issue #8 expands it
+into a student session page in `front-end`.
 
 ```bash
 npm install --prefix front-end
 npm run dev:frontend
 ```
 
-The form currently uses local browser state for validation and confirmation.
-When the backend queue API is merged, the submit handler can call the real queue
-entry endpoint.
+The page currently uses local browser state and demo session data while the
+backend queue API is still being built.

--- a/front-end/README.md
+++ b/front-end/README.md
@@ -1,6 +1,7 @@
 # HelpQ Front End
 
-React + Vite + Tailwind CSS prototype for issue #9: student question form.
+React + Vite + Tailwind CSS prototype for the student frontend. Issue #9 added
+the question form foundation, and Issue #8 expands it into a session join page.
 
 ## Run Locally
 
@@ -18,5 +19,5 @@ npm install
 npm run dev
 ```
 
-The page currently uses local browser state for submission feedback because the
+The page currently uses local browser state and demo session data because the
 backend queue API is not merged into this branch yet.

--- a/front-end/index.html
+++ b/front-end/index.html
@@ -5,9 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"
-      content="HelpQ student question form for joining an office-hours queue."
-    />
-    <title>HelpQ | Question Form</title>
+      content="HelpQ student session page for joining an office-hours queue." />
+    <title>HelpQ | Session Page</title>
   </head>
   <body>
     <div id="root"></div>

--- a/front-end/src/App.jsx
+++ b/front-end/src/App.jsx
@@ -6,35 +6,50 @@ import {
   GraduationCap,
   Hash,
   HelpCircle,
+  Link2,
   Loader2,
   MessageSquareText,
-  UserRound
+  Radio,
+  UserRound,
+  UsersRound
 } from "lucide-react";
 
-const initialForm = {
-  studentName: "",
-  sessionCode: "",
-  question: "",
-  details: ""
+const session = {
+  code: "CS307",
+  title: "CSC 307 Office Hours",
+  host: "Professor Lin and TA team",
+  time: "Today, 2:00 PM - 4:00 PM",
+  location: "Building 14, Room 232",
+  averageHelpMinutes: 8
 };
 
-const sampleQueue = [
+const queueEntries = [
   {
+    id: "maya",
     name: "Maya C.",
-    topic: "Project setup",
-    status: "being helped"
+    question: "Project setup keeps failing on npm install",
+    status: "in-progress"
   },
   {
+    id: "alex",
     name: "Alex R.",
-    topic: "React state bug",
+    question: "React state is not updating after submit",
     status: "waiting"
   },
   {
+    id: "priya",
     name: "Priya S.",
-    topic: "Express route test",
+    question: "Need help testing an Express route",
     status: "waiting"
   }
 ];
+
+const initialForm = {
+  studentName: "",
+  sessionCode: getInitialSessionCode(),
+  question: "",
+  details: ""
+};
 
 function App() {
   const [form, setForm] = useState(initialForm);
@@ -42,35 +57,57 @@ function App() {
   const [submittedEntry, setSubmittedEntry] = useState(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const questionLength = form.question.trim().length;
+  const waitingAhead = queueEntries.filter(
+    (entry) => entry.status === "waiting"
+  ).length;
+
+  const currentPosition = submittedEntry
+    ? submittedEntry.position
+    : waitingAhead + 1;
 
   const waitEstimate = useMemo(() => {
-    const visibleQueueLength = submittedEntry ? sampleQueue.length + 1 : sampleQueue.length;
-    return `${visibleQueueLength * 7}-${visibleQueueLength * 9} min`;
+    const lowEstimate = currentPosition * session.averageHelpMinutes;
+    return `${lowEstimate}-${lowEstimate + 5} min`;
+  }, [currentPosition]);
+
+  const visibleQueue = useMemo(() => {
+    if (!submittedEntry) {
+      return queueEntries;
+    }
+
+    return [
+      ...queueEntries,
+      {
+        id: submittedEntry.id,
+        name: submittedEntry.studentName,
+        question: submittedEntry.question,
+        status: "waiting",
+        isCurrentStudent: true
+      }
+    ];
   }, [submittedEntry]);
 
   function updateField(field, value) {
-    setForm((current) => ({ ...current, [field]: value }));
-    setErrors((current) => ({ ...current, [field]: "" }));
+    setForm((currentForm) => ({ ...currentForm, [field]: value }));
+    setErrors((currentErrors) => ({ ...currentErrors, [field]: "" }));
   }
 
   function validateForm() {
     const nextErrors = {};
+    const sessionCode = form.sessionCode.trim().toUpperCase();
 
-    if (!form.studentName.trim()) {
-      nextErrors.studentName = "Enter your name so the host knows who to call.";
+    if (form.studentName.trim().length < 2) {
+      nextErrors.studentName = "Enter your name before joining the queue.";
     }
 
-    if (!form.sessionCode.trim()) {
-      nextErrors.sessionCode = "Enter the session code your host shared.";
-    } else if (form.sessionCode.trim().length < 4) {
-      nextErrors.sessionCode = "Session codes should be at least 4 characters.";
+    if (!sessionCode) {
+      nextErrors.sessionCode = "Enter the session code from your host.";
+    } else if (sessionCode !== session.code) {
+      nextErrors.sessionCode = `No open session found for ${sessionCode}.`;
     }
 
-    if (!form.question.trim()) {
-      nextErrors.question = "Summarize what you need help with.";
-    } else if (form.question.trim().length < 8) {
-      nextErrors.question = "Add a little more detail so the host can prepare.";
+    if (form.question.trim().length < 8) {
+      nextErrors.question = "Add a short summary of what you need help with.";
     }
 
     return nextErrors;
@@ -88,79 +125,144 @@ function App() {
     setIsSubmitting(true);
 
     window.setTimeout(() => {
-      const entry = {
+      setSubmittedEntry({
+        id: createEntryId(),
         ...form,
-        id: crypto.randomUUID(),
-        position: sampleQueue.length + 1,
+        sessionCode: form.sessionCode.trim().toUpperCase(),
+        position: waitingAhead + 1,
+        status: "waiting",
         submittedAt: new Intl.DateTimeFormat("en", {
           hour: "numeric",
           minute: "2-digit"
         }).format(new Date())
-      };
-
-      setSubmittedEntry(entry);
+      });
       setIsSubmitting(false);
-    }, 450);
+    }, 400);
   }
 
-  function resetForm() {
-    setForm(initialForm);
+  function resetEntry() {
+    setForm({
+      ...initialForm,
+      sessionCode: form.sessionCode.trim().toUpperCase()
+    });
     setErrors({});
     setSubmittedEntry(null);
   }
 
   return (
-    <main className="min-h-screen bg-page text-ink">
-      <section className="mx-auto flex min-h-screen w-full max-w-7xl flex-col px-4 py-5 sm:px-6 lg:px-8">
-        <header className="flex flex-wrap items-center justify-between gap-3 border-b border-coast-sage/70 pb-4">
-          <div className="flex items-center gap-3">
-            <div className="flex h-11 w-11 items-center justify-center rounded-lg bg-poly-green text-stadium-gold">
+    <main className="app-shell">
+      <section className="session-page" aria-labelledby="page-title">
+        <header className="topbar">
+          <div className="brand-lockup">
+            <span className="brand-mark">
               <GraduationCap aria-hidden="true" size={24} />
-            </div>
+            </span>
             <div>
-              <p className="text-sm font-semibold uppercase tracking-wide text-gold-deep">
-                HelpQ
-              </p>
-              <h1 className="text-xl font-semibold sm:text-2xl">
-                Join the office-hours queue
-              </h1>
+              <p className="brand-name">HelpQ</p>
+              <h1 id="page-title">Join a live help session</h1>
             </div>
           </div>
-          <div className="flex items-center gap-2 rounded-full border border-coast-sage bg-sage-soft px-3 py-2 text-sm font-medium text-poly-green">
-            <span className="h-2.5 w-2.5 rounded-full bg-poly-green" />
-            Queue open
+          <div className="live-badge" aria-label="Session is open">
+            <Radio aria-hidden="true" size={17} />
+            Open now
           </div>
         </header>
 
-        <div className="grid flex-1 items-center gap-6 py-6 lg:grid-cols-[minmax(0,1fr)_380px]">
-          <section className="rounded-lg border border-coast-sage/50 bg-panel p-5 shadow-soft sm:p-7 lg:p-8">
-            <div className="mb-6 max-w-2xl">
-              <p className="mb-2 text-sm font-semibold uppercase tracking-wide text-gold-deep">
-                Student check-in
-              </p>
-              <h2 className="text-2xl font-semibold sm:text-3xl">
-                Submit a question for help
-              </h2>
-              <p className="mt-3 max-w-xl text-base leading-7 text-seal">
-                Add your session code, name, and a clear question. HelpQ keeps
-                your place in line and gives the host enough context before
-                they call you.
-              </p>
+        <div className="page-grid">
+          <section className="session-panel" aria-labelledby="session-title">
+            <div className="session-heading">
+              <div>
+                <p className="eyebrow">Session</p>
+                <h2 id="session-title">{session.title}</h2>
+              </div>
+              <span className="session-code">
+                <Hash aria-hidden="true" size={18} />
+                {session.code}
+              </span>
             </div>
 
+            <dl className="session-details">
+              <div>
+                <dt>Host</dt>
+                <dd>{session.host}</dd>
+              </div>
+              <div>
+                <dt>Time</dt>
+                <dd>{session.time}</dd>
+              </div>
+              <div>
+                <dt>Location</dt>
+                <dd>{session.location}</dd>
+              </div>
+            </dl>
+
+            <div className="metrics-row" aria-label="Current queue summary">
+              <Metric
+                icon={<UsersRound aria-hidden="true" size={20} />}
+                label="Waiting"
+                value={submittedEntry ? waitingAhead + 1 : waitingAhead}
+              />
+              <Metric
+                icon={<Clock3 aria-hidden="true" size={20} />}
+                label="Your estimate"
+                value={waitEstimate}
+              />
+            </div>
+
+            <QueuePreview entries={visibleQueue} />
+          </section>
+
+          <section className="join-panel" aria-labelledby="join-title">
             {submittedEntry ? (
-              <Confirmation entry={submittedEntry} onReset={resetForm} />
+              <QueueStatus
+                entry={submittedEntry}
+                estimate={waitEstimate}
+                onReset={resetEntry}
+              />
             ) : (
-              <form className="grid gap-5" noValidate onSubmit={handleSubmit}>
-                <div className="grid gap-5 md:grid-cols-2">
+              <>
+                <div className="join-heading">
+                  <p className="eyebrow">Student entry</p>
+                  <h2 id="join-title">Enter the queue</h2>
+                </div>
+
+                <form className="join-form" noValidate onSubmit={handleSubmit}>
+                  <Field
+                    error={errors.sessionCode}
+                    icon={<Hash aria-hidden="true" size={18} />}
+                    id="sessionCode"
+                    label="Session code">
+                    <input
+                      aria-describedby={
+                        errors.sessionCode ? "sessionCode-message" : undefined
+                      }
+                      aria-invalid={Boolean(errors.sessionCode)}
+                      autoComplete="off"
+                      id="sessionCode"
+                      name="sessionCode"
+                      onChange={(event) =>
+                        updateField(
+                          "sessionCode",
+                          event.target.value.toUpperCase()
+                        )
+                      }
+                      placeholder="CS307"
+                      type="text"
+                      value={form.sessionCode}
+                    />
+                  </Field>
+
                   <Field
                     error={errors.studentName}
                     icon={<UserRound aria-hidden="true" size={18} />}
                     id="studentName"
-                    label="Your name"
-                  >
+                    label="Your name">
                     <input
-                      className={inputClass(errors.studentName)}
+                      aria-describedby={
+                        errors.studentName ? "studentName-message" : undefined
+                      }
+                      aria-invalid={Boolean(errors.studentName)}
+                      autoComplete="name"
                       id="studentName"
                       name="studentName"
                       onChange={(event) =>
@@ -173,157 +275,69 @@ function App() {
                   </Field>
 
                   <Field
-                    error={errors.sessionCode}
-                    icon={<Hash aria-hidden="true" size={18} />}
-                    id="sessionCode"
-                    label="Session code"
-                  >
+                    error={errors.question}
+                    helper={`${form.question.trim().length}/140 characters`}
+                    icon={<HelpCircle aria-hidden="true" size={18} />}
+                    id="question"
+                    label="Question summary">
                     <input
-                      className={inputClass(errors.sessionCode)}
-                      id="sessionCode"
-                      name="sessionCode"
-                      onChange={(event) =>
-                        updateField("sessionCode", event.target.value.toUpperCase())
+                      aria-describedby={
+                        errors.question ? "question-message" : "question-helper"
                       }
-                      placeholder="CS307"
+                      aria-invalid={Boolean(errors.question)}
+                      id="question"
+                      maxLength={140}
+                      name="question"
+                      onChange={(event) =>
+                        updateField("question", event.target.value)
+                      }
+                      placeholder="I need help with my React form"
                       type="text"
-                      value={form.sessionCode}
+                      value={form.question}
                     />
                   </Field>
-                </div>
 
-                <Field
-                  error={errors.question}
-                  helper={`${questionLength}/140 characters`}
-                  icon={<HelpCircle aria-hidden="true" size={18} />}
-                  id="question"
-                  label="Question summary"
-                >
-                  <input
-                    className={inputClass(errors.question)}
-                    id="question"
-                    maxLength={140}
-                    name="question"
-                    onChange={(event) => updateField("question", event.target.value)}
-                    placeholder="I need help debugging my React form validation"
-                    type="text"
-                    value={form.question}
-                  />
-                </Field>
-
-                <Field
-                  helper="Optional, but useful if you already know what you tried."
-                  icon={<MessageSquareText aria-hidden="true" size={18} />}
-                  id="details"
-                  label="Extra details"
-                >
-                  <textarea
-                    className="min-h-32 w-full resize-y rounded-lg border border-coast-sage bg-white px-4 py-3 text-base text-ink transition placeholder:text-seal/60 focus:border-mustang-gold"
+                  <Field
+                    helper="Optional"
+                    icon={<MessageSquareText aria-hidden="true" size={18} />}
                     id="details"
-                    name="details"
-                    onChange={(event) => updateField("details", event.target.value)}
-                    placeholder="Example: I checked the console and the state updates, but the error message does not clear."
-                    value={form.details}
-                  />
-                </Field>
+                    label="Extra details">
+                    <textarea
+                      aria-describedby="details-helper"
+                      id="details"
+                      name="details"
+                      onChange={(event) =>
+                        updateField("details", event.target.value)
+                      }
+                      placeholder="Share what you tried or where you are stuck."
+                      value={form.details}
+                    />
+                  </Field>
 
-                <div className="flex justify-end border-t border-coast-sage/60 pt-5">
                   <button
-                    className="inline-flex min-h-12 items-center justify-center gap-2 rounded-lg bg-poly-green px-5 py-3 text-base font-semibold text-white transition hover:bg-[#0f3527] disabled:cursor-not-allowed disabled:bg-coast-sage disabled:text-poly-green"
+                    className="primary-action"
                     disabled={isSubmitting}
-                    type="submit"
-                  >
+                    type="submit">
                     {isSubmitting ? (
                       <>
                         <Loader2
                           aria-hidden="true"
-                          className="animate-spin"
-                          size={18}
+                          className="spin-icon"
+                          size={19}
                         />
-                        Submitting
+                        Joining queue
                       </>
                     ) : (
                       <>
-                        Submit question
-                        <ArrowRight aria-hidden="true" size={18} />
+                        Join queue
+                        <ArrowRight aria-hidden="true" size={19} />
                       </>
                     )}
                   </button>
-                </div>
-              </form>
+                </form>
+              </>
             )}
           </section>
-
-          <aside className="grid gap-4">
-            <section className="rounded-lg bg-poly-green p-5 text-white shadow-soft">
-              <div className="flex items-center justify-between gap-4">
-                <div>
-                  <p className="text-sm font-medium text-coast-sage">
-                    CSC 307 Office Hours
-                  </p>
-                  <h2 className="mt-1 text-2xl font-semibold">Today, 2-4 PM</h2>
-                </div>
-                <div className="rounded-lg bg-stadium-gold/20 px-3 py-2 text-center">
-                  <p className="text-xs uppercase tracking-wide text-stadium-gold">
-                    Code
-                  </p>
-                  <p className="font-semibold">CS307</p>
-                </div>
-              </div>
-
-              <div className="mt-6 grid grid-cols-2 gap-3">
-                <Metric label="Waiting" value={submittedEntry ? "4" : "3"} />
-                <Metric label="Est. wait" value={waitEstimate} />
-              </div>
-            </section>
-
-            <section className="rounded-lg border border-coast-sage/50 bg-panel p-5 shadow-soft">
-              <div className="mb-4 flex items-center justify-between">
-                <h2 className="text-lg font-semibold">Queue preview</h2>
-                <Clock3 className="text-gold-deep" aria-hidden="true" size={20} />
-              </div>
-              <ol className="grid gap-3">
-                {sampleQueue.map((entry, index) => (
-                  <li
-                    className="flex items-center gap-3 rounded-lg border border-coast-sage/60 bg-sky-soft p-3"
-                    key={entry.name}
-                  >
-                    <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-poly-green text-sm font-semibold text-stadium-gold">
-                      {index + 1}
-                    </span>
-                    <div className="min-w-0 flex-1">
-                      <p className="truncate font-semibold">{entry.name}</p>
-                      <p className="truncate text-sm text-seal">
-                        {entry.topic}
-                      </p>
-                    </div>
-                    <span className="rounded-full bg-green-soft px-2.5 py-1 text-xs font-medium capitalize text-poly-green">
-                      {entry.status}
-                    </span>
-                  </li>
-                ))}
-
-                {submittedEntry ? (
-                  <li className="flex items-center gap-3 rounded-lg border border-mustang-gold bg-gold-soft p-3">
-                    <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-mustang-gold text-sm font-semibold text-white">
-                      {submittedEntry.position}
-                    </span>
-                    <div className="min-w-0 flex-1">
-                      <p className="truncate font-semibold">
-                        {submittedEntry.studentName}
-                      </p>
-                      <p className="truncate text-sm text-seal">
-                        {submittedEntry.question}
-                      </p>
-                    </div>
-                    <span className="rounded-full bg-white px-2.5 py-1 text-xs font-medium text-gold-deep">
-                      you
-                    </span>
-                  </li>
-                ) : null}
-              </ol>
-            </section>
-          </aside>
         </div>
       </section>
     </main>
@@ -332,82 +346,114 @@ function App() {
 
 function Field({ children, error, helper, icon, id, label }) {
   return (
-    <div className="grid gap-2">
-      <label className="flex items-center gap-2 font-semibold" htmlFor={id}>
-        <span className="text-gold-deep">{icon}</span>
+    <div className="field-group">
+      <label htmlFor={id}>
+        <span>{icon}</span>
         {label}
       </label>
       {children}
-      <div className="min-h-5">
-        {error ? (
-          <p className="text-sm font-medium text-red-600">{error}</p>
-        ) : helper ? (
-          <p className="text-sm text-seal">{helper}</p>
-        ) : null}
+      <p
+        className={error ? "field-message error" : "field-message"}
+        id={error ? `${id}-message` : `${id}-helper`}>
+        {error || helper || ""}
+      </p>
+    </div>
+  );
+}
+
+function Metric({ icon, label, value }) {
+  return (
+    <div className="metric">
+      <span className="metric-icon">{icon}</span>
+      <div>
+        <p>{label}</p>
+        <strong>{value}</strong>
       </div>
     </div>
   );
 }
 
-function Confirmation({ entry, onReset }) {
+function QueuePreview({ entries }) {
   return (
-    <div className="rounded-lg border border-coast-sage bg-green-soft p-5">
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-start">
-        <CheckCircle2
-          aria-hidden="true"
-          className="shrink-0 text-poly-green"
-          size={34}
-        />
-        <div className="flex-1">
-          <p className="text-sm font-semibold uppercase tracking-wide text-gold-deep">
-            Added to queue
-          </p>
-          <h3 className="mt-1 text-2xl font-semibold">
-            You are number {entry.position}
-          </h3>
-          <dl className="mt-4 grid gap-3 text-sm sm:grid-cols-2">
-            <div>
-              <dt className="font-semibold text-poly-green">Name</dt>
-              <dd className="mt-1 text-seal">{entry.studentName}</dd>
+    <section className="queue-preview" aria-labelledby="queue-title">
+      <div className="queue-title-row">
+        <h3 id="queue-title">Live queue</h3>
+        <span>{entries.length} active</span>
+      </div>
+      <ol>
+        {entries.map((entry, index) => (
+          <li
+            className={
+              entry.isCurrentStudent ? "queue-row current" : "queue-row"
+            }
+            key={entry.id}>
+            <span className="queue-position">{index + 1}</span>
+            <div className="queue-copy">
+              <strong>{entry.isCurrentStudent ? "You" : entry.name}</strong>
+              <span>{entry.question}</span>
             </div>
-            <div>
-              <dt className="font-semibold text-poly-green">Submitted</dt>
-              <dd className="mt-1 text-seal">{entry.submittedAt}</dd>
-            </div>
-            <div className="sm:col-span-2">
-              <dt className="font-semibold text-poly-green">Question</dt>
-              <dd className="mt-1 text-seal">{entry.question}</dd>
-            </div>
-          </dl>
-          <button
-            className="mt-5 inline-flex min-h-11 items-center justify-center rounded-lg border border-poly-green px-4 py-2 font-semibold text-poly-green transition hover:bg-sage-soft"
-            onClick={onReset}
-            type="button"
-          >
-            Submit another question
-          </button>
+            <StatusPill status={entry.status} />
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}
+
+function QueueStatus({ entry, estimate, onReset }) {
+  return (
+    <div className="status-view">
+      <CheckCircle2 aria-hidden="true" className="status-icon" size={40} />
+      <p className="eyebrow">You are in line</p>
+      <h2 id="join-title">Position {entry.position}</h2>
+      <p className="status-note">
+        Your request is waiting. Keep this page open so you can see when the
+        host starts helping you.
+      </p>
+
+      <dl className="status-details">
+        <div>
+          <dt>Status</dt>
+          <dd>Waiting</dd>
         </div>
-      </div>
+        <div>
+          <dt>Estimated wait</dt>
+          <dd>{estimate}</dd>
+        </div>
+        <div>
+          <dt>Submitted</dt>
+          <dd>{entry.submittedAt}</dd>
+        </div>
+        <div>
+          <dt>Question</dt>
+          <dd>{entry.question}</dd>
+        </div>
+      </dl>
+
+      <button className="secondary-action" onClick={onReset} type="button">
+        <Link2 aria-hidden="true" size={18} />
+        Join another session
+      </button>
     </div>
   );
 }
 
-function Metric({ label, value }) {
-  return (
-    <div className="rounded-lg bg-white/10 p-4">
-      <p className="text-sm text-coast-sage">{label}</p>
-      <p className="mt-1 text-2xl font-semibold">{value}</p>
-    </div>
-  );
+function StatusPill({ status }) {
+  const label = status === "in-progress" ? "In progress" : "Waiting";
+  return <span className={`status-pill ${status}`}>{label}</span>;
 }
 
-function inputClass(hasError) {
-  const base =
-    "min-h-12 w-full rounded-lg border bg-white px-4 text-base text-ink transition placeholder:text-seal/60 focus:border-mustang-gold";
+function createEntryId() {
+  if (typeof crypto !== "undefined" && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
 
-  return hasError
-    ? `${base} border-red-400`
-    : `${base} border-coast-sage`;
+  return `entry-${Date.now()}`;
+}
+
+function getInitialSessionCode() {
+  const params = new URLSearchParams(window.location.search);
+  return (params.get("code") || session.code).toUpperCase();
 }
 
 export default App;

--- a/front-end/src/index.css
+++ b/front-end/src/index.css
@@ -1,10 +1,14 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-
 :root {
-  color: #17352f;
-  background: #f6f8f4;
+  color: #18352f;
+  background: #f7f8f2;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
@@ -23,15 +27,515 @@ body {
 
 button,
 input,
-select,
 textarea {
   font: inherit;
 }
 
+button {
+  cursor: pointer;
+}
+
+button:disabled {
+  cursor: not-allowed;
+}
+
 button:focus-visible,
 input:focus-visible,
-select:focus-visible,
 textarea:focus-visible {
-  outline: 3px solid rgba(189, 139, 19, 0.34);
+  outline: 3px solid rgba(26, 115, 232, 0.24);
   outline-offset: 2px;
+}
+
+.app-shell {
+  min-height: 100vh;
+  background: #f7f8f2;
+  color: #18352f;
+}
+
+.session-page {
+  width: min(1180px, calc(100% - 32px));
+  min-height: 100vh;
+  margin: 0 auto;
+  padding: 24px 0;
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding-bottom: 18px;
+  border-bottom: 1px solid #c8d8cf;
+}
+
+.brand-lockup {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.brand-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  border-radius: 8px;
+  background: #154734;
+  color: #f5ce58;
+}
+
+.brand-name,
+.eyebrow {
+  margin: 0 0 4px;
+  color: #73560f;
+  font-size: 0.84rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 0;
+  font-size: 2.2rem;
+  line-height: 1.1;
+}
+
+h2 {
+  margin-bottom: 0;
+  font-size: 1.8rem;
+  line-height: 1.16;
+}
+
+h3 {
+  margin-bottom: 0;
+  font-size: 1.08rem;
+}
+
+.live-badge,
+.session-code,
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 36px;
+  border-radius: 999px;
+  white-space: nowrap;
+}
+
+.live-badge {
+  border: 1px solid #9ac7c4;
+  background: #e6f5f3;
+  padding: 0 14px;
+  color: #12505b;
+  font-weight: 700;
+}
+
+.page-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.05fr) minmax(340px, 0.75fr);
+  gap: 22px;
+  padding: 24px 0;
+}
+
+.session-panel,
+.join-panel {
+  border: 1px solid #c8d8cf;
+  border-radius: 8px;
+  background: #fffefa;
+  box-shadow: 0 18px 48px rgba(21, 71, 52, 0.1);
+}
+
+.session-panel {
+  padding: 24px;
+}
+
+.join-panel {
+  align-self: start;
+  padding: 24px;
+}
+
+.session-heading,
+.queue-title-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.session-code {
+  border: 1px solid #d6b556;
+  background: #fff4cf;
+  padding: 0 12px;
+  color: #5e4810;
+  font-weight: 800;
+}
+
+.session-details {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+  margin: 24px 0;
+}
+
+.session-details div,
+.status-details div {
+  border-left: 3px solid #5cb8b2;
+  padding-left: 12px;
+}
+
+dt {
+  color: #55605d;
+  font-size: 0.88rem;
+  font-weight: 700;
+}
+
+dd {
+  margin: 4px 0 0;
+  color: #18352f;
+  line-height: 1.45;
+}
+
+.metrics-row {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+  margin-bottom: 24px;
+}
+
+.metric {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-height: 82px;
+  border: 1px solid #c8d8cf;
+  border-radius: 8px;
+  background: #eef5ef;
+  padding: 14px;
+}
+
+.metric-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 8px;
+  background: #154734;
+  color: #f5ce58;
+  flex: 0 0 auto;
+}
+
+.metric p {
+  margin-bottom: 4px;
+  color: #55605d;
+  font-size: 0.88rem;
+  font-weight: 700;
+}
+
+.metric strong {
+  display: block;
+  font-size: 1.55rem;
+  line-height: 1;
+}
+
+.queue-preview {
+  border-top: 1px solid #d7e2dc;
+  padding-top: 20px;
+}
+
+.queue-title-row {
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.queue-title-row span {
+  color: #55605d;
+  font-size: 0.94rem;
+  font-weight: 700;
+}
+
+ol {
+  display: grid;
+  gap: 10px;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.queue-row {
+  display: grid;
+  grid-template-columns: 40px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 12px;
+  min-height: 70px;
+  border: 1px solid #d6e1dc;
+  border-radius: 8px;
+  background: #f8fbfa;
+  padding: 12px;
+}
+
+.queue-row.current {
+  border-color: #bd8b13;
+  background: #fff6dc;
+}
+
+.queue-position {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: #154734;
+  color: #f5ce58;
+  font-weight: 800;
+}
+
+.queue-copy {
+  min-width: 0;
+}
+
+.queue-copy strong,
+.queue-copy span {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.queue-copy span {
+  margin-top: 3px;
+  color: #55605d;
+}
+
+.status-pill {
+  min-width: 98px;
+  padding: 0 10px;
+  font-size: 0.82rem;
+  font-weight: 800;
+}
+
+.status-pill.waiting {
+  background: #e8f1fb;
+  color: #15599c;
+}
+
+.status-pill.in-progress {
+  background: #e9f4ec;
+  color: #1c6f42;
+}
+
+.join-heading {
+  margin-bottom: 22px;
+}
+
+.join-form {
+  display: grid;
+  gap: 16px;
+}
+
+.field-group {
+  display: grid;
+  gap: 7px;
+}
+
+label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 800;
+}
+
+label span {
+  display: inline-flex;
+  color: #73560f;
+}
+
+input,
+textarea {
+  width: 100%;
+  border: 1px solid #bccfc5;
+  border-radius: 8px;
+  background: #ffffff;
+  color: #18352f;
+  transition:
+    border-color 160ms ease,
+    box-shadow 160ms ease;
+}
+
+input {
+  min-height: 48px;
+  padding: 0 13px;
+}
+
+textarea {
+  min-height: 118px;
+  resize: vertical;
+  padding: 12px 13px;
+}
+
+input::placeholder,
+textarea::placeholder {
+  color: #717b78;
+}
+
+input[aria-invalid="true"] {
+  border-color: #c94c4c;
+}
+
+input:focus,
+textarea:focus {
+  border-color: #1a73e8;
+  box-shadow: 0 0 0 4px rgba(26, 115, 232, 0.1);
+}
+
+.field-message {
+  min-height: 20px;
+  margin: 0;
+  color: #55605d;
+  font-size: 0.88rem;
+  line-height: 1.35;
+}
+
+.field-message.error {
+  color: #b3261e;
+  font-weight: 700;
+}
+
+.primary-action,
+.secondary-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 48px;
+  border-radius: 8px;
+  font-weight: 800;
+}
+
+.primary-action {
+  width: 100%;
+  border: 0;
+  background: #154734;
+  color: #ffffff;
+  margin-top: 4px;
+}
+
+.primary-action:hover:not(:disabled) {
+  background: #0f3527;
+}
+
+.primary-action:disabled {
+  background: #9db8ad;
+  color: #213a33;
+}
+
+.secondary-action {
+  border: 1px solid #154734;
+  background: #ffffff;
+  color: #154734;
+  padding: 0 16px;
+}
+
+.secondary-action:hover {
+  background: #eef5ef;
+}
+
+.status-view {
+  display: grid;
+  gap: 16px;
+}
+
+.status-icon {
+  color: #1c6f42;
+}
+
+.status-note {
+  margin: 0;
+  color: #55605d;
+  line-height: 1.55;
+}
+
+.status-details {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+  margin: 0;
+  padding: 18px 0;
+  border-top: 1px solid #d7e2dc;
+  border-bottom: 1px solid #d7e2dc;
+}
+
+.spin-icon {
+  animation: spin 800ms linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (max-width: 900px) {
+  .page-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .join-panel {
+    align-self: stretch;
+  }
+}
+
+@media (max-width: 680px) {
+  .session-page {
+    width: min(100% - 24px, 1180px);
+    padding: 16px 0;
+  }
+
+  .topbar,
+  .session-heading {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .live-badge,
+  .session-code {
+    width: fit-content;
+  }
+
+  .session-panel,
+  .join-panel {
+    padding: 18px;
+  }
+
+  h1 {
+    font-size: 1.55rem;
+  }
+
+  h2 {
+    font-size: 1.4rem;
+  }
+
+  .session-details,
+  .metrics-row,
+  .status-details {
+    grid-template-columns: 1fr;
+  }
+
+  .queue-row {
+    grid-template-columns: 36px minmax(0, 1fr);
+  }
+
+  .status-pill {
+    grid-column: 2;
+    justify-self: start;
+  }
 }


### PR DESCRIPTION
## What changed
Adds the Issue #8 student session page on top of the Issue #9 frontend starter.

This includes:
- Session details and live/open state display
- Session-code validation for the demo `CS307` session
- Student name and question validation before joining
- Local queue submission state with position, status, and estimated wait
- Queue preview that highlights the current student's submitted entry
- Responsive CSS for the session and join panels

## Why
Closes #8 by giving students a session page where they can enter a live help queue before the backend queue API is connected.

## Validation
- `npm run lint:frontend`
- `npm run build:frontend`