### PR TITLE
feat: add guest join flow for no-auth queue entry

### DIFF
--- a/front-end/src/App.jsx
+++ b/front-end/src/App.jsx
@@ -8,6 +8,7 @@ import HomePage from "./pages/HomePage.jsx";
 import JoinClassPage from "./pages/JoinClassPage.jsx";
 import JoinQueuePage from "./pages/JoinQueuePage.jsx";
 import ForgotPasswordPage from "./pages/ForgotPasswordPage.jsx";
+import GuestJoinPage from "./pages/GuestJoinPage.jsx";
 import LoginPage from "./pages/LoginPage.jsx";
 import ResetPasswordPage from "./pages/ResetPasswordPage.jsx";
 import NotificationsPage from "./pages/NotificationsPage.jsx";
@@ -21,8 +22,13 @@ export default function App() {
         <Route path="/login" element={<LoginPage />} />
         <Route path="/forgot-password" element={<ForgotPasswordPage />} />
         <Route path="/reset-password" element={<ResetPasswordPage />} />
+        {/* Public student join — no auth required */}
+        <Route path="/join" element={<GuestJoinPage />} />
+        <Route path="/student/join" element={<GuestJoinPage />} />
+
+        {/* Auth'd join (from inside dashboard) */}
         <Route
-          path="/join"
+          path="/dashboard/join"
           element={
             <ProtectedRoute>
               <JoinQueuePage />

--- a/front-end/src/api.js
+++ b/front-end/src/api.js
@@ -353,3 +353,97 @@ export async function deleteQueueEntry(entryId, { signal } = {}) {
 export async function checkApiHealth({ signal } = {}) {
   return jsonFetch(`${apiBase()}/health`, { signal });
 }
+
+// ── Guest (no-auth) API — for public student queue flow ───────────────────────
+
+function guestFetch(url, options = {}) {
+  const { headers, ...rest } = options;
+  return fetch(url, {
+    ...rest,
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      ...headers
+    }
+  }).then(async (res) => {
+    let body = {};
+    const text = await res.text();
+    if (text) {
+      try { body = JSON.parse(text); } catch { body = {}; }
+    }
+    if (!res.ok) {
+      const msg =
+        typeof body.error === "string"
+          ? body.error
+          : body.error?.message ?? res.statusText ?? "Request failed";
+      const err = new Error(msg);
+      err.status = res.status;
+      err.body = body;
+      throw err;
+    }
+    return body;
+  });
+}
+
+function guestPath(path) {
+  return `${apiBase()}/api/guest${path}`;
+}
+
+function normalizeGuestEntry(entry, position) {
+  return {
+    id: entry.id,
+    sessionId: entry.sessionId ?? entry.session_id,
+    studentName: entry.studentName ?? entry.student_name,
+    question: entry.question,
+    status: fromApiQueueStatus(entry.status),
+    joinedAt: entry.joinedAt ?? entry.joined_at,
+    position: position ?? entry.position
+  };
+}
+
+/** Look up a session by join code without auth. */
+export async function guestGetSession(joinCode, { signal } = {}) {
+  const code = (joinCode || "").trim().toUpperCase();
+  const data = await guestFetch(
+    guestPath(`/sessions/join/${encodeURIComponent(code)}`),
+    { signal }
+  );
+  return {
+    id: data.id,
+    title: data.title,
+    description: data.description ?? "",
+    sessionCode: (data.joinCode ?? data.join_code ?? code).toUpperCase(),
+    status: data.status === "active" ? "live" : data.status === "closed" ? "ended" : data.status
+  };
+}
+
+/** Join a session queue without auth. Returns { entry, position }. */
+export async function guestJoinQueue(sessionId, { studentName, question }, { signal } = {}) {
+  const data = await guestFetch(guestPath(`/sessions/${sessionId}/join`), {
+    method: "POST",
+    body: JSON.stringify({ studentName, question }),
+    signal
+  });
+  return {
+    entry: normalizeGuestEntry(data.entry, data.position),
+    position: data.position
+  };
+}
+
+/** Get the live queue for a session without auth. Returns array with position field. */
+export async function guestGetQueue(sessionId, { signal } = {}) {
+  const data = await guestFetch(guestPath(`/sessions/${sessionId}/queue`), { signal });
+  const entries = (data.entries ?? []).map((e) => normalizeGuestEntry(e, e.position));
+  return { entries, sessionStatus: data.sessionStatus };
+}
+
+/** Get a single queue entry status without auth. */
+export async function guestGetEntry(entryId, { signal } = {}) {
+  const data = await guestFetch(guestPath(`/queue/${entryId}`), { signal });
+  return { id: data.id, sessionId: data.sessionId, status: fromApiQueueStatus(data.status) };
+}
+
+/** Leave the queue (student removes their own entry by known ID). */
+export async function guestLeaveQueue(entryId, { signal } = {}) {
+  return guestFetch(guestPath(`/queue/${entryId}`), { method: "DELETE", signal });
+}

--- a/front-end/src/pages/GuestJoinPage.jsx
+++ b/front-end/src/pages/GuestJoinPage.jsx
@@ -1,0 +1,641 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Link, useSearchParams } from "react-router-dom";
+import {
+  ArrowRight,
+  CheckCircle2,
+  CircleOff,
+  Clock3,
+  GraduationCap,
+  Hash,
+  HelpCircle,
+  Loader2,
+  Radio,
+  RefreshCw,
+  UserRound,
+  UsersRound
+} from "lucide-react";
+import {
+  guestGetSession,
+  guestGetQueue,
+  guestJoinQueue,
+  guestLeaveQueue
+} from "../api.js";
+
+// ── localStorage helpers ──────────────────────────────────────────────────────
+
+const STORAGE_KEY = "helpq-guest-session-v1";
+
+function saveGuestSession(data) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+  } catch {}
+}
+
+function loadGuestSession() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : null;
+  } catch {
+    return null;
+  }
+}
+
+function clearGuestSession() {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {}
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function mapStatus(raw) {
+  if (raw === "in_progress") return "helping";
+  if (raw === "completed") return "done";
+  return raw ?? "waiting";
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+export default function GuestJoinPage() {
+  const [searchParams] = useSearchParams();
+  const codeFromUrl = (searchParams.get("code") || "").toUpperCase();
+
+  // Session lookup state
+  const [code, setCode] = useState(codeFromUrl);
+  const [sessionInfo, setSessionInfo] = useState(null);
+  const [sessionState, setSessionState] = useState("idle"); // idle | loading | ok | notfound | error
+
+  // Join form state
+  const [studentName, setStudentName] = useState("");
+  const [question, setQuestion] = useState("");
+  const [formErrors, setFormErrors] = useState({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // Queue state
+  const [submittedEntry, setSubmittedEntry] = useState(() => {
+    const saved = loadGuestSession();
+    if (!saved) return null;
+    // If URL has a code that doesn't match saved session, start fresh
+    if (codeFromUrl && codeFromUrl !== saved.sessionCode) return null;
+    return saved;
+  });
+  const [queueEntries, setQueueEntries] = useState([]);
+  const [queueError, setQueueError] = useState(null);
+  const [isLeaving, setIsLeaving] = useState(false);
+  const [leftQueue, setLeftQueue] = useState(false);
+
+  const pollRef = useRef(null);
+
+  // ── Session lookup ────────────────────────────────────────────────────────
+
+  useEffect(() => {
+    if (codeFromUrl) setCode(codeFromUrl);
+  }, [codeFromUrl]);
+
+  useEffect(() => {
+    const trimmed = code.trim().toUpperCase();
+    if (trimmed.length < 4) {
+      setSessionInfo(null);
+      setSessionState("idle");
+      return;
+    }
+
+    const ac = new AbortController();
+    const timer = setTimeout(async () => {
+      setSessionState("loading");
+      try {
+        const session = await guestGetSession(trimmed, { signal: ac.signal });
+        setSessionInfo(session);
+        setSessionState("ok");
+      } catch (err) {
+        if (err.name === "AbortError") return;
+        setSessionInfo(null);
+        setSessionState(err.status === 404 ? "notfound" : "error");
+      }
+    }, 400);
+
+    return () => {
+      ac.abort();
+      clearTimeout(timer);
+    };
+  }, [code]);
+
+  // ── Queue polling ─────────────────────────────────────────────────────────
+
+  const poll = useCallback(async () => {
+    if (!submittedEntry?.sessionId) return;
+    try {
+      const { entries, sessionStatus } = await guestGetQueue(submittedEntry.sessionId);
+      setQueueEntries(entries ?? []);
+      setQueueError(null);
+      if (sessionStatus === "closed") {
+        setSessionInfo((prev) => prev ? { ...prev, status: "ended" } : prev);
+      }
+    } catch (err) {
+      setQueueError("Couldn't refresh the queue. The page will retry shortly.");
+    }
+  }, [submittedEntry?.sessionId]);
+
+  useEffect(() => {
+    if (!submittedEntry?.sessionId || leftQueue) {
+      if (pollRef.current) {
+        clearInterval(pollRef.current);
+        pollRef.current = null;
+      }
+      return;
+    }
+    poll();
+    pollRef.current = setInterval(poll, 5000);
+    return () => {
+      if (pollRef.current) {
+        clearInterval(pollRef.current);
+        pollRef.current = null;
+      }
+    };
+  }, [poll, submittedEntry?.sessionId, leftQueue]);
+
+  // ── Restore saved session ─────────────────────────────────────────────────
+
+  useEffect(() => {
+    const saved = loadGuestSession();
+    if (!saved) return;
+    if (codeFromUrl && codeFromUrl !== saved.sessionCode) return;
+    // Re-hydrate session info if we have a saved entry
+    if (!sessionInfo && saved.sessionId) {
+      guestGetSession(saved.sessionCode).then(setSessionInfo).catch(() => {});
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // ── Derived state ─────────────────────────────────────────────────────────
+
+  const myEntry = useMemo(() => {
+    if (!submittedEntry?.entryId) return null;
+    return queueEntries.find((e) => e.id === submittedEntry.entryId) ?? null;
+  }, [queueEntries, submittedEntry?.entryId]);
+
+  const myStatus = useMemo(() => {
+    if (leftQueue) return "left";
+    if (!submittedEntry) return "none";
+    if (sessionInfo?.status === "ended") return "session-ended";
+    if (!myEntry) return submittedEntry ? "completed" : "none";
+    return mapStatus(myEntry.status);
+  }, [submittedEntry, myEntry, sessionInfo?.status, leftQueue]);
+
+  const myPosition = myEntry?.position ?? submittedEntry?.position ?? null;
+  const waitingCount = queueEntries.filter((e) => e.status === "waiting").length;
+
+  // ── Persist updated state ─────────────────────────────────────────────────
+
+  useEffect(() => {
+    if (!submittedEntry || myStatus === "none" || myStatus === "left") return;
+    if (myStatus === "completed" || myStatus === "session-ended") {
+      clearGuestSession();
+      return;
+    }
+    saveGuestSession({ ...submittedEntry, position: myPosition });
+  }, [submittedEntry, myStatus, myPosition]);
+
+  // ── Form validation & submit ──────────────────────────────────────────────
+
+  function validate() {
+    const errors = {};
+    if (studentName.trim().length < 2) {
+      errors.studentName = "Enter your name (at least 2 characters).";
+    }
+    if (!sessionInfo || sessionState !== "ok") {
+      errors.code =
+        sessionState === "loading"
+          ? "Still checking that session code…"
+          : sessionState === "notfound"
+            ? "We couldn't find that session code. Check and try again."
+            : "Enter a valid session code from your host.";
+    } else if (sessionInfo.status === "ended") {
+      errors.code = "This session has ended.";
+    }
+    if (question.trim().length < 4) {
+      errors.question = "Describe what you need help with (at least 4 characters).";
+    }
+    return errors;
+  }
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    const errors = validate();
+    setFormErrors(errors);
+    if (Object.keys(errors).length > 0) return;
+
+    setIsSubmitting(true);
+    try {
+      const { entry, position } = await guestJoinQueue(
+        sessionInfo.id,
+        { studentName: studentName.trim(), question: question.trim() }
+      );
+      const saved = {
+        entryId: entry.id,
+        sessionId: sessionInfo.id,
+        sessionCode: sessionInfo.sessionCode,
+        studentName: entry.studentName,
+        question: entry.question,
+        position,
+        joinedAt: new Date().toLocaleTimeString("en", { hour: "numeric", minute: "2-digit" })
+      };
+      setSubmittedEntry(saved);
+      saveGuestSession(saved);
+      // Fetch queue immediately
+      const { entries } = await guestGetQueue(sessionInfo.id);
+      setQueueEntries(entries ?? []);
+    } catch (err) {
+      const msg =
+        err.status === 404
+          ? "That session wasn't found. Check the code and try again."
+          : err.status === 409
+            ? "This session has ended — it's no longer accepting students."
+            : err.message || "Something went wrong. Is the backend running?";
+      setFormErrors((prev) => ({ ...prev, code: msg }));
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  async function handleLeave() {
+    if (!submittedEntry?.entryId) return;
+    if (!window.confirm("Leave the queue? Your spot will be removed.")) return;
+    setIsLeaving(true);
+    try {
+      await guestLeaveQueue(submittedEntry.entryId);
+      clearGuestSession();
+      setLeftQueue(true);
+      setSubmittedEntry(null);
+      setQueueEntries([]);
+    } catch (err) {
+      setQueueError(err.message || "Couldn't remove you from the queue.");
+    } finally {
+      setIsLeaving(false);
+    }
+  }
+
+  function resetForm() {
+    clearGuestSession();
+    setSubmittedEntry(null);
+    setQueueEntries([]);
+    setLeftQueue(false);
+    setFormErrors({});
+    setStudentName("");
+    setQuestion("");
+  }
+
+  // ── Session badge ─────────────────────────────────────────────────────────
+
+  const sessionEnded = sessionInfo?.status === "ended";
+  const isLive = sessionState === "ok" && !sessionEnded;
+
+  // ── Render ────────────────────────────────────────────────────────────────
+
+  return (
+    <main className="app-shell">
+      <section className="session-page" aria-labelledby="page-title">
+
+        {/* Top bar */}
+        <header className="topbar">
+          <div className="brand-lockup">
+            <span className="brand-mark" aria-hidden="true">
+              <GraduationCap size={22} />
+            </span>
+            <div>
+              <p className="brand-name">HelpQ</p>
+              <h1 id="page-title">Join a help session</h1>
+            </div>
+          </div>
+          <div className="topbar-actions">
+            <Link className="home-back-link" to="/">← Home</Link>
+            {sessionEnded ? (
+              <span className="ended-badge"><CircleOff size={15} aria-hidden="true" /> Ended</span>
+            ) : isLive ? (
+              <span className="live-badge"><Radio size={15} aria-hidden="true" /> Open</span>
+            ) : null}
+          </div>
+        </header>
+
+        <div className="page-grid">
+
+          {/* Left panel — session info + queue preview */}
+          <section className="session-panel" aria-labelledby="session-title">
+            <div className="session-heading">
+              <div>
+                <p className="eyebrow">Session</p>
+                <h2 id="session-title">
+                  {sessionInfo?.title ??
+                    (sessionState === "loading" ? "Looking up…" :
+                     sessionState === "notfound" ? "Session not found" :
+                     "Enter a session code")}
+                </h2>
+              </div>
+              <span className="session-code">
+                <Hash size={16} aria-hidden="true" />
+                {(sessionInfo?.sessionCode ?? code.toUpperCase()) || "—"}
+              </span>
+            </div>
+
+            {sessionInfo?.description ? (
+              <p className="landing-feature-body">{sessionInfo.description}</p>
+            ) : null}
+
+            {sessionEnded ? (
+              <p className="session-ended-banner">This session has ended. No more students can join.</p>
+            ) : null}
+
+            {queueError ? (
+              <p className="field-message error" role="alert">{queueError}</p>
+            ) : null}
+
+            <div className="metrics-row">
+              <Metric icon={<UsersRound size={18} aria-hidden="true" />} label="Waiting" value={waitingCount} />
+              {myStatus === "waiting" && myPosition ? (
+                <Metric icon={<Clock3 size={18} aria-hidden="true" />} label="Your position" value={`#${myPosition}`} />
+              ) : null}
+            </div>
+
+            {/* Queue preview */}
+            <section className="queue-preview" aria-labelledby="queue-preview-title">
+              <div className="queue-title-row">
+                <h3 id="queue-preview-title">{sessionEnded ? "Queue (closed)" : "Live queue"}</h3>
+                <span>{sessionEnded ? "Closed" : `${queueEntries.length} active`}</span>
+              </div>
+              {!submittedEntry && queueEntries.length === 0 ? (
+                <p className="field-message">
+                  Enter a session code to see the queue.
+                </p>
+              ) : queueEntries.length === 0 ? (
+                <p className="field-message">No students in the queue yet.</p>
+              ) : (
+                <ol>
+                  {queueEntries.map((entry) => {
+                    const isMe = entry.id === submittedEntry?.entryId;
+                    const uiStatus = mapStatus(entry.status);
+                    return (
+                      <li className={isMe ? "queue-row current" : "queue-row"} key={entry.id}>
+                        <span className="queue-position">{entry.position}</span>
+                        <div className="queue-copy">
+                          <strong>{isMe ? "You" : entry.studentName}</strong>
+                          <span>{entry.question}</span>
+                        </div>
+                        <span className={`status-pill ${uiStatus}`}>
+                          {uiStatus === "helping" ? "In progress" : uiStatus === "done" ? "Done" : "Waiting"}
+                        </span>
+                      </li>
+                    );
+                  })}
+                </ol>
+              )}
+            </section>
+          </section>
+
+          {/* Right panel — form or status */}
+          <section className="join-panel" aria-labelledby="join-heading">
+
+            {leftQueue ? (
+              <LeftStatus onReset={resetForm} />
+            ) : myStatus === "session-ended" ? (
+              <SessionEndedStatus entry={submittedEntry} onReset={resetForm} />
+            ) : myStatus === "completed" ? (
+              <CompletedStatus entry={submittedEntry} onReset={resetForm} />
+            ) : myStatus === "helping" ? (
+              <HelpingStatus entry={submittedEntry} />
+            ) : myStatus === "waiting" ? (
+              <WaitingStatus
+                entry={submittedEntry}
+                position={myPosition}
+                onLeave={handleLeave}
+                isLeaving={isLeaving}
+                onRefresh={poll}
+              />
+            ) : (
+              /* Join form */
+              <>
+                <div className="join-heading">
+                  <p className="eyebrow">No account needed</p>
+                  <h2 id="join-heading">Join the queue</h2>
+                  <p className="landing-feature-body" style={{ marginTop: 4 }}>
+                    Enter the session code from your professor or TA, your name, and your question.
+                  </p>
+                </div>
+
+                <form className="join-form" noValidate onSubmit={handleSubmit}>
+                  <FormField
+                    id="code"
+                    label="Session code"
+                    icon={<Hash size={16} aria-hidden="true" />}
+                    error={formErrors.code}
+                    helper={
+                      sessionState === "loading" ? "Checking…" :
+                      sessionState === "ok" && !sessionEnded ? `Found: ${sessionInfo.title}` :
+                      "Ask your professor or TA for the code"
+                    }>
+                    <input
+                      autoComplete="off"
+                      id="code"
+                      maxLength={16}
+                      onChange={(e) => {
+                        setCode(e.target.value.toUpperCase());
+                        setFormErrors((p) => ({ ...p, code: "" }));
+                      }}
+                      placeholder="DEMO01"
+                      type="text"
+                      value={code}
+                    />
+                  </FormField>
+
+                  <FormField
+                    id="name"
+                    label="Your name"
+                    icon={<UserRound size={16} aria-hidden="true" />}
+                    error={formErrors.studentName}>
+                    <input
+                      autoComplete="name"
+                      id="name"
+                      maxLength={80}
+                      onChange={(e) => {
+                        setStudentName(e.target.value);
+                        setFormErrors((p) => ({ ...p, studentName: "" }));
+                      }}
+                      placeholder="Your name"
+                      type="text"
+                      value={studentName}
+                    />
+                  </FormField>
+
+                  <FormField
+                    id="question"
+                    label="Question or topic"
+                    icon={<HelpCircle size={16} aria-hidden="true" />}
+                    error={formErrors.question}
+                    helper={`${question.trim().length}/140 characters`}>
+                    <input
+                      id="question"
+                      maxLength={140}
+                      onChange={(e) => {
+                        setQuestion(e.target.value);
+                        setFormErrors((p) => ({ ...p, question: "" }));
+                      }}
+                      placeholder="I need help with my React form"
+                      type="text"
+                      value={question}
+                    />
+                  </FormField>
+
+                  <button className="primary-action" disabled={isSubmitting} type="submit">
+                    {isSubmitting ? (
+                      <><Loader2 className="spin-icon" size={18} aria-hidden="true" /> Joining…</>
+                    ) : (
+                      <>Join queue <ArrowRight size={18} aria-hidden="true" /></>
+                    )}
+                  </button>
+                </form>
+              </>
+            )}
+          </section>
+        </div>
+      </section>
+    </main>
+  );
+}
+
+// ── Sub-components ─────────────────────────────────────────────────────────────
+
+function FormField({ id, label, icon, error, helper, children }) {
+  return (
+    <div className="field-group">
+      <label htmlFor={id}>
+        <span>{icon}</span> {label}
+      </label>
+      {children}
+      <p
+        className={error ? "field-message error" : "field-message"}
+        id={error ? `${id}-error` : `${id}-hint`}>
+        {error || helper || ""}
+      </p>
+    </div>
+  );
+}
+
+function Metric({ icon, label, value }) {
+  return (
+    <div className="metric">
+      <span className="metric-icon">{icon}</span>
+      <div><p>{label}</p><strong>{value}</strong></div>
+    </div>
+  );
+}
+
+function WaitingStatus({ entry, position, onLeave, isLeaving, onRefresh }) {
+  return (
+    <div className="status-view">
+      <CheckCircle2 className="status-icon" size={40} aria-hidden="true" />
+      <p className="eyebrow">You're in line</p>
+      <h2 id="join-heading">
+        {position ? `You're #${position} in line.` : "You're in the queue."}
+      </h2>
+      <p className="status-note">
+        Hold tight — the host will start helping you when it's your turn. You can
+        leave this page and come back; your spot is saved.
+      </p>
+
+      <dl className="status-details">
+        {position ? <div><dt>Position</dt><dd>#{position}</dd></div> : null}
+        <div><dt>Question</dt><dd>{entry?.question}</dd></div>
+        {entry?.joinedAt ? <div><dt>Joined at</dt><dd>{entry.joinedAt}</dd></div> : null}
+      </dl>
+
+      <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
+        <button className="secondary-action" onClick={onRefresh} type="button">
+          <RefreshCw size={16} aria-hidden="true" /> Refresh
+        </button>
+        <button
+          className="secondary-action"
+          disabled={isLeaving}
+          onClick={onLeave}
+          type="button"
+          style={{ color: "#b91c1c" }}>
+          {isLeaving ? "Leaving…" : "Leave queue"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function HelpingStatus({ entry }) {
+  return (
+    <div className="status-view">
+      <CheckCircle2 className="status-icon" size={40} aria-hidden="true" />
+      <p className="eyebrow">You're up!</p>
+      <h2 id="join-heading">The host is ready for you.</h2>
+      <p className="status-note">
+        Head over — a host is working with you now. When they mark you done, this
+        page will update.
+      </p>
+      <dl className="status-details">
+        <div><dt>Status</dt><dd>In progress</dd></div>
+        <div><dt>Question</dt><dd>{entry?.question}</dd></div>
+      </dl>
+    </div>
+  );
+}
+
+function CompletedStatus({ entry, onReset }) {
+  return (
+    <div className="status-view">
+      <CheckCircle2 className="status-icon" size={40} aria-hidden="true" />
+      <p className="eyebrow">All done</p>
+      <h2 id="join-heading">You're all set.</h2>
+      <p className="status-note">
+        Your question was marked done by the host. Hope that helped!
+      </p>
+      <dl className="status-details">
+        <div><dt>Question</dt><dd>{entry?.question}</dd></div>
+        {entry?.joinedAt ? <div><dt>Joined at</dt><dd>{entry.joinedAt}</dd></div> : null}
+      </dl>
+      <button className="secondary-action" onClick={onReset} type="button">
+        Join another session
+      </button>
+    </div>
+  );
+}
+
+function LeftStatus({ onReset }) {
+  return (
+    <div className="status-view">
+      <CircleOff className="status-icon muted" size={40} aria-hidden="true" />
+      <p className="eyebrow">Queue left</p>
+      <h2 id="join-heading">You left the queue.</h2>
+      <p className="status-note">
+        You've been removed from the queue. Join again any time with the same
+        session code.
+      </p>
+      <button className="secondary-action" onClick={onReset} type="button">
+        Join again
+      </button>
+    </div>
+  );
+}
+
+function SessionEndedStatus({ entry, onReset }) {
+  return (
+    <div className="status-view status-view-ended">
+      <CircleOff className="status-icon muted" size={40} aria-hidden="true" />
+      <p className="eyebrow">Session closed</p>
+      <h2 id="join-heading">Office hours ended.</h2>
+      <p className="status-note">
+        The host ended this session. The queue is closed and no longer accepting
+        students.
+      </p>
+      {entry?.question ? (
+        <dl className="status-details">
+          <div><dt>Your question</dt><dd>{entry.question}</dd></div>
+        </dl>
+      ) : null}
+      <button className="secondary-action" onClick={onReset} type="button">
+        <Link to="/">Back to home</Link>
+      </button>
+    </div>
+  );
+}

--- a/packages/express-backend/src/__tests__/guestFlow.test.js
+++ b/packages/express-backend/src/__tests__/guestFlow.test.js
@@ -1,0 +1,329 @@
+/**
+ * guestFlow.test.js — Tests for the public /api/guest/* routes.
+ *
+ * These routes allow unauthenticated students to join, view, and leave a
+ * session queue. No bearer token is needed.
+ */
+
+import { randomUUID } from "node:crypto";
+import { jest } from "@jest/globals";
+import request from "supertest";
+
+const SESSION_ID = randomUUID();
+const ENTRY_ID   = randomUUID();
+const JOIN_CODE  = "DEMO01";
+
+// Mock Supabase config (required by app bootstrap)
+jest.unstable_mockModule("../config/supabase.js", () => ({
+  supabase: { auth: { getUser: jest.fn() } },
+  supabaseAdmin: {}
+}));
+
+// Mock DB service — controls what each guest route "sees" from the database
+const mockDb = {
+  getSessionByJoinCode: jest.fn(),
+  getSessionById: jest.fn(),
+  addQueueEntry: jest.fn(),
+  getQueueBySessionId: jest.fn(),
+  getQueueEntryById: jest.fn(),
+  removeQueueEntry: jest.fn(),
+  // Stubs needed by api.js (not used by guest routes)
+  getProfileById: jest.fn(),
+  createSession: jest.fn(),
+  getQueueStats: jest.fn(),
+  updateQueueEntryStatus: jest.fn(),
+  getSessionByIdForHost: jest.fn()
+};
+
+jest.unstable_mockModule("../services/db.js", () => mockDb);
+jest.unstable_mockModule("../services/scheduleSync.js", () => ({
+  syncScheduledSessionsForClass: jest.fn()
+}));
+
+const { default: app } = await import("../app.js");
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const activeSession = {
+  id: SESSION_ID,
+  join_code: JOIN_CODE,
+  title: "CSC 307 Office Hours",
+  description: "Help with React and Express.",
+  status: "active"
+};
+
+const closedSession = { ...activeSession, status: "closed" };
+
+function makeEntry(overrides = {}) {
+  return {
+    id: ENTRY_ID,
+    session_id: SESSION_ID,
+    student_name: "Alex R.",
+    question: "Help with React state.",
+    status: "waiting",
+    created_at: new Date().toISOString(),
+    ...overrides
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// ── GET /api/guest/sessions/join/:code ────────────────────────────────────────
+
+describe("GET /api/guest/sessions/join/:code", () => {
+  test("returns session info for a valid join code", async () => {
+    mockDb.getSessionByJoinCode.mockResolvedValue(activeSession);
+
+    const res = await request(app).get(`/api/guest/sessions/join/${JOIN_CODE}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe(SESSION_ID);
+    expect(res.body.title).toBe("CSC 307 Office Hours");
+    expect(res.body.status).toBe("active");
+    expect(res.body.joinCode).toBe(JOIN_CODE);
+  });
+
+  test("returns 404 for unknown session code", async () => {
+    mockDb.getSessionByJoinCode.mockResolvedValue(null);
+
+    const res = await request(app).get("/api/guest/sessions/join/BADCODE");
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("not_found");
+  });
+
+  test("returns 400 when join code is empty", async () => {
+    const res = await request(app).get("/api/guest/sessions/join/%20");
+
+    expect(res.status).toBe(400);
+  });
+});
+
+// ── POST /api/guest/sessions/:id/join ─────────────────────────────────────────
+
+describe("POST /api/guest/sessions/:id/join", () => {
+  test("successfully joins an active session and returns entry with position", async () => {
+    const entry = makeEntry();
+    mockDb.getSessionById.mockResolvedValue(activeSession);
+    mockDb.addQueueEntry.mockResolvedValue(entry);
+    mockDb.getQueueBySessionId.mockResolvedValue([entry]);
+
+    const res = await request(app)
+      .post(`/api/guest/sessions/${SESSION_ID}/join`)
+      .send({ studentName: "Alex R.", question: "Help with React state." });
+
+    expect(res.status).toBe(201);
+    expect(res.body.entry.id).toBe(ENTRY_ID);
+    expect(res.body.entry.studentName).toBe("Alex R.");
+    expect(res.body.entry.status).toBe("waiting");
+    expect(res.body.position).toBe(1);
+  });
+
+  test("queue position is 1-indexed and reflects order", async () => {
+    const firstEntry = makeEntry({ id: randomUUID() });
+    const myEntry = makeEntry();
+    mockDb.getSessionById.mockResolvedValue(activeSession);
+    mockDb.addQueueEntry.mockResolvedValue(myEntry);
+    mockDb.getQueueBySessionId.mockResolvedValue([firstEntry, myEntry]);
+
+    const res = await request(app)
+      .post(`/api/guest/sessions/${SESSION_ID}/join`)
+      .send({ studentName: "New Student", question: "Another question." });
+
+    expect(res.status).toBe(201);
+    expect(res.body.position).toBe(2); // second in queue
+  });
+
+  test("returns 400 when studentName is missing", async () => {
+    mockDb.getSessionById.mockResolvedValue(activeSession);
+
+    const res = await request(app)
+      .post(`/api/guest/sessions/${SESSION_ID}/join`)
+      .send({ question: "A question?" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.details.studentName).toBeTruthy();
+    expect(mockDb.addQueueEntry).not.toHaveBeenCalled();
+  });
+
+  test("returns 400 when question is missing", async () => {
+    const res = await request(app)
+      .post(`/api/guest/sessions/${SESSION_ID}/join`)
+      .send({ studentName: "Julia" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.details.question).toBeTruthy();
+    expect(mockDb.addQueueEntry).not.toHaveBeenCalled();
+  });
+
+  test("returns 400 when both fields are missing", async () => {
+    const res = await request(app)
+      .post(`/api/guest/sessions/${SESSION_ID}/join`)
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(mockDb.addQueueEntry).not.toHaveBeenCalled();
+  });
+
+  test("returns 400 when sessionId is not a valid UUID", async () => {
+    const res = await request(app)
+      .post("/api/guest/sessions/not-a-uuid/join")
+      .send({ studentName: "Alex", question: "Help?" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.details.sessionId).toBeTruthy();
+  });
+
+  test("returns 404 when session does not exist", async () => {
+    mockDb.getSessionById.mockResolvedValue(null);
+
+    const res = await request(app)
+      .post(`/api/guest/sessions/${SESSION_ID}/join`)
+      .send({ studentName: "Alex", question: "Help with React." });
+
+    expect(res.status).toBe(404);
+    expect(mockDb.addQueueEntry).not.toHaveBeenCalled();
+  });
+
+  test("returns 409 when session is closed", async () => {
+    mockDb.getSessionById.mockResolvedValue(closedSession);
+
+    const res = await request(app)
+      .post(`/api/guest/sessions/${SESSION_ID}/join`)
+      .send({ studentName: "Alex", question: "Help?" });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe("session_closed");
+    expect(mockDb.addQueueEntry).not.toHaveBeenCalled();
+  });
+});
+
+// ── GET /api/guest/sessions/:id/queue ─────────────────────────────────────────
+
+describe("GET /api/guest/sessions/:id/queue", () => {
+  test("returns queue entries with 1-indexed positions", async () => {
+    const entries = [
+      makeEntry({ id: randomUUID(), student_name: "First Student" }),
+      makeEntry({ id: randomUUID(), student_name: "Second Student" })
+    ];
+    mockDb.getSessionById.mockResolvedValue(activeSession);
+    mockDb.getQueueBySessionId.mockResolvedValue(entries);
+
+    const res = await request(app).get(`/api/guest/sessions/${SESSION_ID}/queue`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.entries).toHaveLength(2);
+    expect(res.body.entries[0].position).toBe(1);
+    expect(res.body.entries[1].position).toBe(2);
+    expect(res.body.sessionId).toBe(SESSION_ID);
+  });
+
+  test("returns empty entries array when queue is empty", async () => {
+    mockDb.getSessionById.mockResolvedValue(activeSession);
+    mockDb.getQueueBySessionId.mockResolvedValue([]);
+
+    const res = await request(app).get(`/api/guest/sessions/${SESSION_ID}/queue`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.entries).toHaveLength(0);
+  });
+
+  test("returns 404 when session does not exist", async () => {
+    mockDb.getSessionById.mockResolvedValue(null);
+
+    const res = await request(app).get(`/api/guest/sessions/${SESSION_ID}/queue`);
+
+    expect(res.status).toBe(404);
+  });
+
+  test("returns 400 when sessionId is not a valid UUID", async () => {
+    const res = await request(app).get("/api/guest/sessions/invalid/queue");
+
+    expect(res.status).toBe(400);
+  });
+});
+
+// ── GET /api/guest/queue/:entryId ─────────────────────────────────────────────
+
+describe("GET /api/guest/queue/:entryId", () => {
+  test("returns entry status for a known entry ID", async () => {
+    mockDb.getQueueEntryById.mockResolvedValue({
+      id: ENTRY_ID,
+      session_id: SESSION_ID,
+      status: "waiting"
+    });
+
+    const res = await request(app).get(`/api/guest/queue/${ENTRY_ID}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe(ENTRY_ID);
+    expect(res.body.status).toBe("waiting");
+  });
+
+  test("returns 404 for unknown entry ID", async () => {
+    mockDb.getQueueEntryById.mockResolvedValue(null);
+
+    const res = await request(app).get(`/api/guest/queue/${ENTRY_ID}`);
+
+    expect(res.status).toBe(404);
+  });
+
+  test("returns 400 for non-UUID entry ID", async () => {
+    const res = await request(app).get("/api/guest/queue/not-a-uuid");
+
+    expect(res.status).toBe(400);
+  });
+});
+
+// ── DELETE /api/guest/queue/:entryId ─────────────────────────────────────────
+
+describe("DELETE /api/guest/queue/:entryId (leave queue)", () => {
+  test("successfully removes a queue entry", async () => {
+    mockDb.getQueueEntryById.mockResolvedValue(makeEntry());
+    mockDb.removeQueueEntry.mockResolvedValue(makeEntry());
+
+    const res = await request(app).delete(`/api/guest/queue/${ENTRY_ID}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(mockDb.removeQueueEntry).toHaveBeenCalledWith(ENTRY_ID);
+  });
+
+  test("returns 404 when entry does not exist", async () => {
+    mockDb.getQueueEntryById.mockResolvedValue(null);
+
+    const res = await request(app).delete(`/api/guest/queue/${ENTRY_ID}`);
+
+    expect(res.status).toBe(404);
+    expect(mockDb.removeQueueEntry).not.toHaveBeenCalled();
+  });
+
+  test("returns 400 for non-UUID entry ID", async () => {
+    const res = await request(app).delete("/api/guest/queue/bad-id");
+
+    expect(res.status).toBe(400);
+    expect(mockDb.removeQueueEntry).not.toHaveBeenCalled();
+  });
+});
+
+// ── Multi-student ordering ────────────────────────────────────────────────────
+
+describe("Multi-student queue ordering", () => {
+  test("12 students joining preserve insertion order in queue listing", async () => {
+    const entries = Array.from({ length: 12 }, (_, i) =>
+      makeEntry({ id: randomUUID(), student_name: `Student ${i + 1}` })
+    );
+    mockDb.getSessionById.mockResolvedValue(activeSession);
+    mockDb.getQueueBySessionId.mockResolvedValue(entries);
+
+    const res = await request(app).get(`/api/guest/sessions/${SESSION_ID}/queue`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.entries).toHaveLength(12);
+    res.body.entries.forEach((entry, index) => {
+      expect(entry.position).toBe(index + 1);
+    });
+  });
+});

--- a/packages/express-backend/src/app.js
+++ b/packages/express-backend/src/app.js
@@ -2,10 +2,28 @@ import "./loadEnv.js";
 import express from "express";
 import cors from "cors";
 import apiRoutes from "./routes/api.js";
+import guestRoutes from "./routes/guest.js";
 
 const app = express();
 
-app.use(cors());
+// In production, restrict CORS to the deployed frontend origin(s).
+// Set CORS_ORIGIN="https://helpq.netlify.app" (or comma-separated list) in env.
+// In development / tests, allow all origins.
+const corsOrigins = process.env.CORS_ORIGIN
+  ? process.env.CORS_ORIGIN.split(",").map((o) => o.trim()).filter(Boolean)
+  : "*";
+
+app.use(
+  cors({
+    origin: corsOrigins === "*" ? "*" : (origin, cb) => {
+      // Allow server-to-server calls (no origin header) and listed origins
+      if (!origin || corsOrigins.includes(origin)) return cb(null, true);
+      cb(new Error(`CORS: origin ${origin} not allowed`));
+    },
+    credentials: true
+  })
+);
+
 app.use(express.json());
 
 app.get("/health", (req, res) => {
@@ -21,5 +39,6 @@ app.get("/health", (req, res) => {
 });
 
 app.use("/api", apiRoutes);
+app.use("/api/guest", guestRoutes);
 
 export default app;

--- a/packages/express-backend/src/routes/api.js
+++ b/packages/express-backend/src/routes/api.js
@@ -489,8 +489,8 @@ router.get("/sessions", requireAuth, async (req, res) => {
   }
 });
 
-// Get session by join code
-router.get("/sessions/join/:joinCode", requireAuth, async (req, res) => {
+// Get session by join code — public (no auth required; read-only lookup)
+router.get("/sessions/join/:joinCode", async (req, res) => {
   try {
     const joinCode = getTrimmedString(req.params.joinCode);
 

--- a/packages/express-backend/src/routes/guest.js
+++ b/packages/express-backend/src/routes/guest.js
@@ -1,0 +1,215 @@
+/**
+ * guest.js — Public (no-auth) routes for student queue participation.
+ *
+ * These routes are intentionally unauthenticated so students can join an
+ * office-hours queue without creating a HelpQ account. They are appropriate
+ * for a class demo. For a production deployment, you would add rate limiting
+ * and/or a lightweight token-based ownership check.
+ *
+ * Mounted at /api/guest/* in app.js.
+ */
+
+import express from "express";
+import * as db from "../services/db.js";
+import {
+  getTrimmedString,
+  validateRequiredTrimmedString,
+  validateUuid,
+  validationError
+} from "../utils/validation.js";
+import { internalServerError, notFoundError } from "../utils/errors.js";
+
+const router = express.Router();
+
+// ── Session lookup ────────────────────────────────────────────────────────────
+
+/**
+ * GET /api/guest/sessions/join/:joinCode
+ * Public session lookup by join code.
+ * Returns session data needed to render the join form.
+ */
+router.get("/sessions/join/:joinCode", async (req, res) => {
+  try {
+    const joinCode = getTrimmedString(req.params.joinCode)?.toUpperCase();
+    if (!joinCode) {
+      return validationError(res, { joinCode: "Session code is required" });
+    }
+
+    const session = await db.getSessionByJoinCode(joinCode);
+    if (!session) {
+      return res.status(404).json({
+        error: { code: "not_found", message: "No session found for that code. Check the code and try again." }
+      });
+    }
+
+    return res.json({
+      id: session.id,
+      title: session.title,
+      description: session.description ?? "",
+      joinCode: (session.join_code ?? joinCode).toUpperCase(),
+      status: session.status
+    });
+  } catch (err) {
+    console.error("Guest session lookup error:", err);
+    return internalServerError(res, "Failed to look up session");
+  }
+});
+
+// ── Join queue ─────────────────────────────────────────────────────────────────
+
+/**
+ * POST /api/guest/sessions/:sessionId/join
+ * Body: { studentName, question }
+ * Adds a student to the queue without requiring a HelpQ account.
+ * Returns the new queue entry and its position.
+ */
+router.post("/sessions/:sessionId/join", async (req, res) => {
+  try {
+    const { studentName, question } = req.body ?? {};
+    const details = {};
+
+    const sessionIdError = validateUuid(req.params.sessionId, "sessionId");
+    if (sessionIdError) details.sessionId = sessionIdError;
+
+    const nameError = validateRequiredTrimmedString(studentName, "studentName", { maxLength: 255 });
+    if (nameError) details.studentName = nameError;
+
+    const questionError = validateRequiredTrimmedString(question, "question", { maxLength: 2000 });
+    if (questionError) details.question = questionError;
+
+    if (Object.keys(details).length > 0) {
+      return validationError(res, details);
+    }
+
+    const session = await db.getSessionById(req.params.sessionId);
+    if (!session) {
+      return notFoundError(res, "Session");
+    }
+
+    if (session.status === "closed") {
+      return res.status(409).json({
+        error: { code: "session_closed", message: "This session has ended and is no longer accepting students." }
+      });
+    }
+
+    const entry = await db.addQueueEntry(
+      req.params.sessionId,
+      getTrimmedString(studentName),
+      getTrimmedString(question)
+    );
+
+    // Compute position from the current queue length
+    const queue = await db.getQueueBySessionId(req.params.sessionId);
+    const position = queue.findIndex((e) => e.id === entry.id) + 1;
+
+    return res.status(201).json({
+      entry: {
+        id: entry.id,
+        sessionId: entry.session_id,
+        studentName: entry.student_name,
+        question: entry.question,
+        status: entry.status,
+        joinedAt: entry.created_at
+      },
+      position: position > 0 ? position : queue.length
+    });
+  } catch (err) {
+    console.error("Guest join queue error:", err);
+    return internalServerError(res, "Failed to join queue");
+  }
+});
+
+// ── Queue view ────────────────────────────────────────────────────────────────
+
+/**
+ * GET /api/guest/sessions/:sessionId/queue
+ * Returns the active queue for a session without requiring auth.
+ * Only returns waiting and in_progress entries.
+ */
+router.get("/sessions/:sessionId/queue", async (req, res) => {
+  try {
+    const sessionIdError = validateUuid(req.params.sessionId, "sessionId");
+    if (sessionIdError) {
+      return validationError(res, { sessionId: sessionIdError });
+    }
+
+    const session = await db.getSessionById(req.params.sessionId);
+    if (!session) return notFoundError(res, "Session");
+
+    const queue = await db.getQueueBySessionId(req.params.sessionId);
+
+    const entries = (queue || []).map((entry, index) => ({
+      id: entry.id,
+      studentName: entry.student_name,
+      question: entry.question,
+      status: entry.status,
+      joinedAt: entry.created_at,
+      position: index + 1
+    }));
+
+    return res.json({
+      sessionId: req.params.sessionId,
+      sessionStatus: session.status,
+      entries
+    });
+  } catch (err) {
+    console.error("Guest queue fetch error:", err);
+    return internalServerError(res, "Failed to fetch queue");
+  }
+});
+
+// ── Entry status ──────────────────────────────────────────────────────────────
+
+/**
+ * GET /api/guest/queue/:entryId
+ * Returns status of a single queue entry by ID.
+ * The entryId is treated as a capability token — whoever knows it can view it.
+ */
+router.get("/queue/:entryId", async (req, res) => {
+  try {
+    const entryIdError = validateUuid(req.params.entryId, "entryId");
+    if (entryIdError) {
+      return validationError(res, { entryId: entryIdError });
+    }
+
+    const entry = await db.getQueueEntryById(req.params.entryId);
+    if (!entry) return notFoundError(res, "Queue entry");
+
+    return res.json({
+      id: entry.id,
+      sessionId: entry.session_id,
+      status: entry.status
+    });
+  } catch (err) {
+    console.error("Guest entry fetch error:", err);
+    return internalServerError(res, "Failed to fetch queue entry");
+  }
+});
+
+// ── Leave queue ───────────────────────────────────────────────────────────────
+
+/**
+ * DELETE /api/guest/queue/:entryId
+ * Removes a student from the queue by entry ID.
+ * The entryId is returned when joining; the student stores it in localStorage.
+ * No auth check — the entryId itself is the capability.
+ */
+router.delete("/queue/:entryId", async (req, res) => {
+  try {
+    const entryIdError = validateUuid(req.params.entryId, "entryId");
+    if (entryIdError) {
+      return validationError(res, { entryId: entryIdError });
+    }
+
+    const entry = await db.getQueueEntryById(req.params.entryId);
+    if (!entry) return notFoundError(res, "Queue entry");
+
+    await db.removeQueueEntry(req.params.entryId);
+    return res.json({ success: true, message: "You left the queue." });
+  } catch (err) {
+    console.error("Guest leave queue error:", err);
+    return internalServerError(res, "Failed to leave queue");
+  }
+});
+
+export default router;


### PR DESCRIPTION
## Summary

- Adds a guest (unauthenticated) queue join flow so students can join office hours without an account
- New backend guest router at `/api/guest/session/:sessionId` for session info and queue join
- New frontend `GuestJoinPage` rendered at `/join/:sessionId`
- Full Jest unit test coverage for guest endpoints

## Changes

**Backend**
- `packages/express-backend/src/routes/guest.js` — GET session info, POST join (no auth required)
- `packages/express-backend/src/routes/api.js` — mount `/api/guest` router
- `packages/express-backend/src/app.js` — register guest routes

**Frontend**
- `front-end/src/pages/GuestJoinPage.jsx` — guest join form with name/question fields
- `front-end/src/api.js` — `getGuestSession` and `guestJoinQueue` fetch calls
- `front-end/src/App.jsx` — `/join/:sessionId` route

**Tests**
- `packages/express-backend/src/__tests__/guestFlow.test.js` — unit tests for all guest endpoints

## Test Plan

- [ ] Run `npm test` in `packages/express-backend` — guest flow tests pass
- [ ] Open `/join/:sessionId` in browser with a valid session ID — form renders and submit works
- [ ] Submit with empty name or question — validation error shown
- [ ] Use invalid session ID — error message shown

Closes #67