### PR TITLE
feat: public landing page and quick-start session flow

### DIFF
--- a/front-end/src/App.jsx
+++ b/front-end/src/App.jsx
@@ -8,11 +8,19 @@ import HomePage from "./pages/HomePage.jsx";
 import JoinClassPage from "./pages/JoinClassPage.jsx";
 import JoinQueuePage from "./pages/JoinQueuePage.jsx";
 import ForgotPasswordPage from "./pages/ForgotPasswordPage.jsx";
+import LandingPage from "./pages/LandingPage.jsx";
 import LoginPage from "./pages/LoginPage.jsx";
 import ResetPasswordPage from "./pages/ResetPasswordPage.jsx";
 import NotificationsPage from "./pages/NotificationsPage.jsx";
 import SettingsPage from "./pages/SettingsPage.jsx";
 import ViewQueuePage from "./pages/ViewQueuePage.jsx";
+import QuickStartSessionPage from "./pages/QuickStartSessionPage.jsx";
+import { useApp } from "./context/useApp.js";
+
+function HomeOrLanding() {
+  const { user } = useApp();
+  return user ? <HomePage /> : <LandingPage />;
+}
 
 export default function App() {
   return (
@@ -30,14 +38,7 @@ export default function App() {
           }
         />
 
-        <Route
-          path="/"
-          element={
-            <ProtectedRoute>
-              <HomePage />
-            </ProtectedRoute>
-          }
-        />
+        <Route path="/" element={<HomeOrLanding />} />
         <Route
           path="/notifications"
           element={
@@ -59,6 +60,15 @@ export default function App() {
           element={
             <ProtectedRoute>
               <JoinClassPage />
+            </ProtectedRoute>
+          }
+        />
+        {/* Quick session creation — professor creates a session without a class */}
+        <Route
+          path="/sessions/new"
+          element={
+            <ProtectedRoute>
+              <QuickStartSessionPage />
             </ProtectedRoute>
           }
         />

--- a/front-end/src/index.css
+++ b/front-end/src/index.css
@@ -2516,3 +2516,197 @@ textarea:focus {
     width: 100%;
   }
 }
+
+/* ── Landing page ───────────────────────────────────────────────────────── */
+
+.landing-shell {
+  min-height: 100vh;
+  background: #f7f8f2;
+  color: #18352f;
+}
+
+.landing-nav {
+  border-bottom: 1px solid #c8d8cf;
+  background: #fff;
+}
+
+.landing-nav-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  width: min(1100px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 14px 0;
+}
+
+.landing-brand-text {
+  font-size: 1.25rem;
+  font-weight: 800;
+  color: #154734;
+}
+
+.landing-nav-actions {
+  display: flex;
+  gap: 10px;
+}
+
+.landing-hero {
+  background: #154734;
+  color: #f7f8f2;
+  padding: 72px 0 80px;
+}
+
+.landing-hero-inner {
+  width: min(700px, calc(100% - 40px));
+  margin: 0 auto;
+  text-align: center;
+}
+
+.landing-headline {
+  font-size: clamp(2.4rem, 6vw, 3.8rem);
+  font-weight: 900;
+  line-height: 1.05;
+  margin-bottom: 20px;
+  color: #fff;
+}
+
+.landing-headline-accent {
+  color: #f5ce58;
+}
+
+.landing-subtitle {
+  font-size: 1.15rem;
+  line-height: 1.6;
+  margin-bottom: 36px;
+  color: rgba(247, 248, 242, 0.88);
+}
+
+.landing-cta-row {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.landing-cta-btn {
+  padding: 12px 28px;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.landing-features {
+  padding: 64px 0;
+}
+
+.landing-features-inner {
+  width: min(1100px, calc(100% - 40px));
+  margin: 0 auto;
+}
+
+.landing-section-title {
+  font-size: 1.75rem;
+  font-weight: 800;
+  margin-bottom: 32px;
+  color: #154734;
+  text-align: center;
+}
+
+.landing-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 20px;
+}
+
+.landing-feature-card {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.landing-feature-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 52px;
+  height: 52px;
+  border-radius: 12px;
+  background: #e5f5ed;
+  color: #154734;
+  flex-shrink: 0;
+}
+
+.landing-feature-body {
+  color: #4a6358;
+  line-height: 1.55;
+  margin: 0;
+}
+
+.landing-demo {
+  padding: 64px 0;
+  background: #f0f5f2;
+  border-top: 1px solid #c8d8cf;
+  border-bottom: 1px solid #c8d8cf;
+}
+
+.landing-demo-inner {
+  width: min(680px, calc(100% - 40px));
+  margin: 0 auto;
+}
+
+.landing-demo-steps {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.landing-demo-steps li {
+  display: flex;
+  gap: 18px;
+  align-items: flex-start;
+}
+
+.landing-step-num {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  background: #154734;
+  color: #f5ce58;
+  font-weight: 800;
+  font-size: 0.95rem;
+  margin-top: 1px;
+}
+
+.landing-demo-steps li > div {
+  padding-top: 5px;
+  color: #2d4a3e;
+  line-height: 1.55;
+}
+
+.landing-code {
+  background: #dde8e2;
+  border-radius: 4px;
+  padding: 1px 6px;
+  font-size: 0.9rem;
+  font-family: ui-monospace, "Cascadia Code", monospace;
+}
+
+.landing-guest-note {
+  margin-top: 16px;
+  font-size: 0.9rem;
+  color: rgba(247, 248, 242, 0.7);
+}
+
+.landing-footer {
+  text-align: center;
+  padding: 28px 16px;
+  color: #5a7166;
+  font-size: 0.875rem;
+}

--- a/front-end/src/pages/HomePage.jsx
+++ b/front-end/src/pages/HomePage.jsx
@@ -107,6 +107,12 @@ export default function HomePage() {
                 {liveSessions.length} Active
               </span>
             ) : null}
+            {isInstructor ? (
+              <Link className="btn btn-gold btn-compact" to="/sessions/new">
+                <Plus aria-hidden="true" size={16} />
+                Quick start
+              </Link>
+            ) : null}
           </div>
 
           {sessionsError ? (

--- a/front-end/src/pages/LandingPage.jsx
+++ b/front-end/src/pages/LandingPage.jsx
@@ -1,0 +1,156 @@
+import { Link } from "react-router-dom";
+import { GraduationCap, ListOrdered, Users, Zap } from "lucide-react";
+
+export default function LandingPage() {
+  return (
+    <div className="landing-shell">
+      {/* ── Nav ─────────────────────────────────────────────────── */}
+      <nav className="landing-nav">
+        <div className="landing-nav-inner">
+          <div className="brand-lockup">
+            <span className="brand-mark" aria-hidden="true">
+              <GraduationCap size={22} />
+            </span>
+            <span className="landing-brand-text">HelpQ</span>
+          </div>
+          <div className="landing-nav-actions">
+            <Link className="btn btn-secondary btn-compact" to="/login">
+              Sign in
+            </Link>
+            <Link
+              className="btn btn-gold btn-compact"
+              to="/login"
+              state={{ mode: "sign-up" }}>
+              Get started
+            </Link>
+          </div>
+        </div>
+      </nav>
+
+      {/* ── Hero ────────────────────────────────────────────────── */}
+      <section className="landing-hero">
+        <div className="landing-hero-inner">
+          <p className="eyebrow">Cal Poly SWE 307</p>
+          <h1 className="landing-headline">
+            Office hours,<br />
+            <span className="landing-headline-accent">organized.</span>
+          </h1>
+          <p className="landing-subtitle">
+            HelpQ is a live office-hours queue for students, TAs, and
+            professors. Students join with a code, see their position in
+            real time, and get helped in order — no more crowding the hallway.
+          </p>
+          <div className="landing-cta-row">
+            <Link className="btn btn-gold landing-cta-btn" to="/join">
+              Join a session
+            </Link>
+            <Link className="btn btn-secondary landing-cta-btn" to="/login">
+              Professor sign in
+            </Link>
+          </div>
+          <p className="landing-guest-note">
+            Students don&apos;t need an account — just enter the code from your
+            professor or TA.
+          </p>
+        </div>
+      </section>
+
+      {/* ── How it works ─────────────────────────────────────────── */}
+      <section className="landing-features">
+        <div className="landing-features-inner">
+          <h2 className="landing-section-title">How it works</h2>
+          <div className="landing-cards">
+            <FeatureCard
+              icon={<Zap size={28} aria-hidden="true" />}
+              title="Professor starts a session"
+              body="One click creates a live help session with a shareable join
+                    code. No account required for observers."
+            />
+            <FeatureCard
+              icon={<Users size={28} aria-hidden="true" />}
+              title="Students join the queue"
+              body="Students enter the code, their name, and their question.
+                    They see their position and an estimated wait time — updated
+                    live."
+            />
+            <FeatureCard
+              icon={<ListOrdered size={28} aria-hidden="true" />}
+              title="Host manages the queue"
+              body="The host dashboard shows every student, their question, and
+                    status. One tap marks a student as being helped, then done."
+            />
+          </div>
+        </div>
+      </section>
+
+      {/* ── Demo flow ────────────────────────────────────────────── */}
+      <section className="landing-demo">
+        <div className="landing-demo-inner">
+          <h2 className="landing-section-title">Try the live demo</h2>
+          <p style={{ color: "#4a6358", marginBottom: 20, textAlign: "center" }}>
+            The demo session <strong>DEMO01</strong> is pre-loaded with 12 students.
+          </p>
+          <div style={{ display: "flex", gap: 10, justifyContent: "center", marginBottom: 28, flexWrap: "wrap" }}>
+            <Link className="btn btn-gold landing-cta-btn" to="/join?code=DEMO01">
+              Join as student (DEMO01)
+            </Link>
+            <Link className="btn btn-secondary landing-cta-btn" to="/login">
+              Sign in as professor
+            </Link>
+          </div>
+          <ol className="landing-demo-steps">
+            <li>
+              <span className="landing-step-num">1</span>
+              <div>
+                <strong>Student:</strong> Click &ldquo;Join as student (DEMO01)&rdquo; above — enter your name and question. No account needed.
+              </div>
+            </li>
+            <li>
+              <span className="landing-step-num">2</span>
+              <div>
+                <strong>Professor:</strong> Sign in → open the host dashboard at{" "}
+                <code className="landing-code">/sessions/DEMO01/manage</code>.
+              </div>
+            </li>
+            <li>
+              <span className="landing-step-num">3</span>
+              <div>
+                <strong>Professor:</strong> Click &ldquo;Start helping&rdquo; — watch the student&apos;s page update live.
+              </div>
+            </li>
+            <li>
+              <span className="landing-step-num">4</span>
+              <div>
+                <strong>Professor:</strong> Click &ldquo;Mark done&rdquo; — student sees &ldquo;You&apos;re all set.&rdquo;
+              </div>
+            </li>
+          </ol>
+        </div>
+      </section>
+
+      {/* ── Footer ──────────────────────────────────────────────── */}
+      <footer className="landing-footer">
+        <p>
+          Built for CSC 307 &mdash; Cal Poly SLO &nbsp;·&nbsp;{" "}
+          <a
+            className="text-link"
+            href="https://github.com/juliameylu/HelpQ"
+            rel="noopener noreferrer"
+            target="_blank">
+            GitHub
+          </a>
+        </p>
+      </footer>
+    </div>
+  );
+}
+
+function FeatureCard({ icon, title, body }) {
+  return (
+    <div className="card landing-feature-card">
+      <span className="landing-feature-icon">{icon}</span>
+      <h3>{title}</h3>
+      <p className="landing-feature-body">{body}</p>
+    </div>
+  );
+}

--- a/front-end/src/pages/QuickStartSessionPage.jsx
+++ b/front-end/src/pages/QuickStartSessionPage.jsx
@@ -1,0 +1,200 @@
+import { useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { CheckCircle2, ClipboardCopy, GraduationCap, Loader2, Radio } from "lucide-react";
+import DashboardLayout from "../components/DashboardLayout.jsx";
+import { createSession } from "../api.js";
+import { useApp } from "../context/useApp.js";
+
+export default function QuickStartSessionPage() {
+  const { user } = useApp();
+  const navigate = useNavigate();
+
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [errors, setErrors] = useState({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [created, setCreated] = useState(null); // { session, joinUrl }
+  const [copied, setCopied] = useState(false);
+
+  function validate() {
+    const errs = {};
+    if (title.trim().length < 2) {
+      errs.title = "Session title is required (at least 2 characters).";
+    }
+    return errs;
+  }
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    const errs = validate();
+    setErrors(errs);
+    if (Object.keys(errs).length > 0) return;
+
+    setIsSubmitting(true);
+    try {
+      const { session } = await createSession({
+        title: title.trim(),
+        description: description.trim()
+      });
+      const joinUrl = `${window.location.origin}/join?code=${session.sessionCode}`;
+      setCreated({ session, joinUrl });
+    } catch (err) {
+      setErrors({ submit: err.message || "Could not create session. Make sure you are signed in." });
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  async function handleCopy() {
+    if (!created?.joinUrl) return;
+    try {
+      await navigator.clipboard.writeText(created.joinUrl);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // clipboard unavailable — user can copy manually
+    }
+  }
+
+  if (created) {
+    return (
+      <DashboardLayout>
+        <div className="page-stack standalone-page">
+          <div className="card" style={{ maxWidth: 560, margin: "0 auto" }}>
+            <div style={{ display: "flex", alignItems: "center", gap: 12, marginBottom: 4 }}>
+              <CheckCircle2 size={28} color="#154734" aria-hidden="true" />
+              <h1 style={{ margin: 0, fontSize: "1.45rem" }}>Session created!</h1>
+            </div>
+            <p style={{ color: "#4a6358", marginBottom: 20 }}>
+              Share the join code or link below. Students can join without creating an account.
+            </p>
+
+            <dl className="status-details" style={{ marginBottom: 20 }}>
+              <div>
+                <dt>Session title</dt>
+                <dd><strong>{created.session.title}</strong></dd>
+              </div>
+              <div>
+                <dt>Session code</dt>
+                <dd>
+                  <span className="session-code" style={{ fontSize: "1.4rem", fontWeight: 800, letterSpacing: 2 }}>
+                    {created.session.sessionCode}
+                  </span>
+                </dd>
+              </div>
+              <div>
+                <dt>Student join link</dt>
+                <dd style={{ wordBreak: "break-all" }}>
+                  <a className="text-link" href={created.joinUrl} target="_blank" rel="noopener noreferrer">
+                    {created.joinUrl}
+                  </a>
+                </dd>
+              </div>
+            </dl>
+
+            <div style={{ display: "flex", gap: 10, flexWrap: "wrap", marginBottom: 16 }}>
+              <button
+                className="btn btn-secondary btn-compact"
+                onClick={handleCopy}
+                type="button">
+                <ClipboardCopy size={16} aria-hidden="true" />
+                {copied ? "Copied!" : "Copy join link"}
+              </button>
+              <Link
+                className="btn btn-gold btn-compact"
+                to={`/sessions/${created.session.sessionCode}/manage`}>
+                <Radio size={16} aria-hidden="true" />
+                Open host dashboard
+              </Link>
+            </div>
+
+            <p className="field-message">
+              You can also find this session on your{" "}
+              <Link className="text-link" to="/">home dashboard</Link>.
+            </p>
+          </div>
+        </div>
+      </DashboardLayout>
+    );
+  }
+
+  return (
+    <DashboardLayout>
+      <div className="page-stack standalone-page">
+        <div className="card" style={{ maxWidth: 520, margin: "0 auto" }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 4 }}>
+            <span className="brand-mark" aria-hidden="true">
+              <GraduationCap size={20} />
+            </span>
+            <h1 style={{ margin: 0, fontSize: "1.45rem" }}>Start a help session</h1>
+          </div>
+          <p style={{ color: "#4a6358", marginBottom: 24 }}>
+            Create a live office-hours queue. Students join with the session code
+            — no account required.
+          </p>
+
+          <form noValidate onSubmit={handleSubmit} style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+            <div className="field-group">
+              <label htmlFor="session-title">Session title</label>
+              <input
+                id="session-title"
+                autoComplete="off"
+                autoFocus
+                maxLength={120}
+                onChange={(e) => {
+                  setTitle(e.target.value);
+                  setErrors((p) => ({ ...p, title: "" }));
+                }}
+                placeholder="CSC 307 Office Hours"
+                type="text"
+                value={title}
+                aria-describedby={errors.title ? "title-error" : undefined}
+                aria-invalid={Boolean(errors.title)}
+              />
+              {errors.title ? (
+                <p className="field-message error" id="title-error" role="alert">
+                  {errors.title}
+                </p>
+              ) : null}
+            </div>
+
+            <div className="field-group">
+              <label htmlFor="session-desc">
+                Description <span style={{ fontWeight: 400, color: "#7a9a8e" }}>(optional)</span>
+              </label>
+              <textarea
+                id="session-desc"
+                maxLength={300}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="Help with React, Express, Supabase, and testing."
+                rows={3}
+                value={description}
+              />
+            </div>
+
+            {errors.submit ? (
+              <p className="field-message error" role="alert">{errors.submit}</p>
+            ) : null}
+
+            <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
+              <button
+                className="btn btn-gold"
+                disabled={isSubmitting}
+                style={{ flex: 1 }}
+                type="submit">
+                {isSubmitting ? (
+                  <><Loader2 className="spin-icon" size={18} aria-hidden="true" /> Creating…</>
+                ) : (
+                  "Create session"
+                )}
+              </button>
+              <Link className="btn btn-secondary" to="/" style={{ flex: "0 0 auto" }}>
+                Cancel
+              </Link>
+            </div>
+          </form>
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/packages/express-backend/src/app.js
+++ b/packages/express-backend/src/app.js
@@ -8,15 +8,20 @@ const app = express();
 
 // In production, restrict CORS to the deployed frontend origin(s).
 // Set CORS_ORIGIN="https://helpq.netlify.app" (or comma-separated list) in env.
-// In development / tests, allow all origins.
-const corsOrigins = process.env.CORS_ORIGIN
+// In development / tests, default to local frontend origins when CORS_ORIGIN is unset.
+const configuredCorsOrigins = process.env.CORS_ORIGIN
   ? process.env.CORS_ORIGIN.split(",").map((o) => o.trim()).filter(Boolean)
-  : "*";
+  : [];
+const corsOrigins = configuredCorsOrigins.length
+  ? configuredCorsOrigins
+  : process.env.NODE_ENV === "production"
+    ? []
+    : ["http://localhost:5173", "http://127.0.0.1:5173"];
 
 app.use(
   cors({
-    origin: corsOrigins === "*" ? "*" : (origin, cb) => {
-      // Allow server-to-server calls (no origin header) and listed origins
+    origin: (origin, cb) => {
+      // Allow server-to-server calls (no origin header) and listed origins.
       if (!origin || corsOrigins.includes(origin)) return cb(null, true);
       cb(new Error(`CORS: origin ${origin} not allowed`));
     },


### PR DESCRIPTION
## Summary

- Adds a public `LandingPage` shown to unauthenticated visitors at `/`
- `HomeOrLanding` root component renders landing page or home dashboard based on auth state
- New `QuickStartSessionPage` at `/sessions/new` for instructors to start an ad-hoc session
- "Quick start" button added to `HomePage` for instructor users
- Resolves merge conflicts with latest `main` updates and preserves both landing and guest join routing
- Hardens backend CORS defaults to avoid permissive wildcard origin behavior with credentials

## Changes

- `front-end/src/pages/LandingPage.jsx` — hero section, feature cards, how-it-works steps, login/sign-up CTA
- `front-end/src/pages/QuickStartSessionPage.jsx` — session name form, creates session and redirects to queue view
- `front-end/src/pages/HomePage.jsx` — "Quick start" button for instructors
- `front-end/src/App.jsx` — `HomeOrLanding` component, `/sessions/new` route under `ProtectedRoute`, merged with `GuestJoinPage` import/routes from `main`
- `front-end/src/index.css` — landing page styles (hero, cards, steps, footer)
- `packages/express-backend/src/app.js` — CORS origin handling updated to require explicit allowed origins (with local dev defaults) instead of wildcard fallback

## Test Plan

- [ ] Visit `/` while logged out — landing page renders
- [ ] Visit `/` while logged in — home dashboard renders (no regression)
- [ ] Instructor clicks "Quick start" — navigates to `/sessions/new`
- [ ] Fill in session name and submit — session created, redirects to manage queue
- [ ] Non-instructor visits `/sessions/new` — redirected by ProtectedRoute
- [ ] Verify guest join routes (`/join`, `/student/join`) still render correctly after merge conflict resolution
- [ ] Run backend tests (`npm test`) and confirm passing