### PR TITLE
Enforce active sessions for queue joins

### DIFF
--- a/packages/express-backend/src/__tests__/accessControl.test.js
+++ b/packages/express-backend/src/__tests__/accessControl.test.js
@@ -8,6 +8,7 @@ const mockDb = {
   createSession: jest.fn(),
   getQueueEntryById: jest.fn(),
   getSessionById: jest.fn(),
+  getSessionByJoinCode: jest.fn(),
   getSessionByIdForHost: jest.fn(),
   removeQueueEntry: jest.fn(),
   updateQueueEntryStatus: jest.fn()
@@ -113,6 +114,21 @@ test("POST /api/sessions creates a session with a valid bearer token", async () 
     "Help",
     null
   );
+});
+
+test("GET /api/sessions/join/:joinCode returns 404 when no active session exists", async () => {
+  authenticateAs(ownerUser);
+  mockDb.getSessionByJoinCode.mockResolvedValue(null);
+
+  const response = await request(app)
+    .get("/api/sessions/join/CLOSED1")
+    .set("Authorization", "Bearer real-token");
+
+  expect(response.status).toBe(404);
+  expect(response.body.error.message).toBe("Session not found");
+  expect(mockDb.getSessionByJoinCode).toHaveBeenCalledWith("CLOSED1", {
+    activeOnly: true
+  });
 });
 
 test("PATCH /api/queue/:entryId/status returns 401 when no bearer token is provided", async () => {

--- a/packages/express-backend/src/__tests__/studentQueueAccess.test.js
+++ b/packages/express-backend/src/__tests__/studentQueueAccess.test.js
@@ -5,7 +5,8 @@ import request from "supertest";
 const mockGetUser = jest.fn();
 const mockDb = {
   addQueueEntry: jest.fn(),
-  getProfileById: jest.fn()
+  getProfileById: jest.fn(),
+  getSessionById: jest.fn()
 };
 
 // focused on role checks only
@@ -83,6 +84,10 @@ test("POST /api/sessions/:sessionId/queue creates an entry for a student account
     full_name: "Student User",
     role: "student"
   });
+  mockDb.getSessionById.mockResolvedValue({
+    id: sessionId,
+    status: "active"
+  });
   mockDb.addQueueEntry.mockResolvedValue({
     id: randomUUID(),
     session_id: sessionId,
@@ -105,6 +110,55 @@ test("POST /api/sessions/:sessionId/queue creates an entry for a student account
     "Student User",
     "Help"
   );
+});
+
+test("POST /api/sessions/:sessionId/queue returns 404 when the session does not exist", async () => {
+  signInAs(studentUser);
+  mockDb.getProfileById.mockResolvedValue({
+    id: studentUser.id,
+    email: "student@helpq.test",
+    full_name: "Student User",
+    role: "student"
+  });
+  mockDb.getSessionById.mockResolvedValue(null);
+
+  const response = await request(app)
+    .post(`/api/sessions/${sessionId}/queue`)
+    .set("Authorization", "Bearer student-token")
+    .send({
+      question: "Help"
+    });
+
+  expect(response.status).toBe(404);
+  expect(response.body.error.message).toBe("Session not found");
+  expect(mockDb.addQueueEntry).not.toHaveBeenCalled();
+});
+
+test("POST /api/sessions/:sessionId/queue returns 400 when the session is closed", async () => {
+  signInAs(studentUser);
+  mockDb.getProfileById.mockResolvedValue({
+    id: studentUser.id,
+    email: "student@helpq.test",
+    full_name: "Student User",
+    role: "student"
+  });
+  mockDb.getSessionById.mockResolvedValue({
+    id: sessionId,
+    status: "closed"
+  });
+
+  const response = await request(app)
+    .post(`/api/sessions/${sessionId}/queue`)
+    .set("Authorization", "Bearer student-token")
+    .send({
+      question: "Help"
+    });
+
+  expect(response.status).toBe(400);
+  expect(response.body.error.message).toBe(
+    "Session is closed. Ask your host for an active session."
+  );
+  expect(mockDb.addQueueEntry).not.toHaveBeenCalled();
 });
 
 test("POST /api/sessions/:sessionId/queue returns 401 when the profile is missing", async () => {

--- a/packages/express-backend/src/routes/api.js
+++ b/packages/express-backend/src/routes/api.js
@@ -22,6 +22,7 @@ import {
   validationError
 } from "../utils/validation.js";
 import {
+  badRequestError,
   forbiddenError,
   internalServerError,
   notFoundError
@@ -500,7 +501,9 @@ router.get("/sessions/join/:joinCode", requireAuth, async (req, res) => {
       });
     }
 
-    const session = await db.getSessionByJoinCode(joinCode);
+    const session = await db.getSessionByJoinCode(joinCode, {
+      activeOnly: true
+    });
 
     if (!session) {
       return notFoundError(res, "Session");
@@ -668,6 +671,19 @@ router.post(
 
       if (Object.keys(details).length > 0) {
         return validationError(res, details);
+      }
+
+      const session = await db.getSessionById(req.params.sessionId);
+
+      if (!session) {
+        return notFoundError(res, "Session");
+      }
+
+      if (session.status !== "active") {
+        return badRequestError(
+          res,
+          "Session is closed. Ask your host for an active session."
+        );
       }
 
       const entry = await db.addQueueEntry(

--- a/packages/express-backend/src/services/db.js
+++ b/packages/express-backend/src/services/db.js
@@ -425,12 +425,20 @@ export const createSession = async (
   return data[0];
 };
 
-export const getSessionByJoinCode = async (joinCode) => {
-  const { data, error } = await supabaseAdmin
+export const getSessionByJoinCode = async (
+  joinCode,
+  { activeOnly = false } = {}
+) => {
+  let query = supabaseAdmin
     .from("sessions")
     .select("*")
-    .eq("join_code", joinCode)
-    .single();
+    .eq("join_code", joinCode);
+
+  if (activeOnly) {
+    query = query.eq("status", "active");
+  }
+
+  const { data, error } = await query.single();
 
   if (error && error.code !== "PGRST116") throw error;
   return data;


### PR DESCRIPTION
## Summary

This PR completes issue 35 by enforcing session validity at the backend, not just in the frontend UI.

Students should only be able to join a queue if the session both exists and is still active. Before this change, the join page checked for that in the client, but the backend still allowed direct queue submission against a closed session ID.

## Changes

- Updated session join-code lookup to return only active sessions
- Added backend validation on queue submission to reject:
  - missing sessions
  - closed sessions
- Added test coverage for:
  - join lookup when no active session exists
  - queue submission to a missing session
  - queue submission to a closed session

## Why

This closes the gap between UI behavior and backend enforcement. It prevents invalid or closed sessions from being joinable through direct API calls and makes issue 35 fully enforced server-side.
