### PR TITLE
Fix host access to session queue endpoints

### DIFF
--- a/packages/express-backend/src/__tests__/sessionManagement.test.js
+++ b/packages/express-backend/src/__tests__/sessionManagement.test.js
@@ -230,6 +230,7 @@ describe("PATCH /api/sessions/:id/status — closing a session", () => {
 
     expect(res.status).toBe(404);
   });
+
 });
 
 // ── Queue ordering ────────────────────────────────────────────────────────────
@@ -311,6 +312,25 @@ describe("GET /api/sessions/:id/queue — queue ordering", () => {
       .set("Authorization", "Bearer host-token");
 
     expect(res.status).toBe(404);
+  });
+
+  test("allows the host to view queue when the linked class row is missing", async () => {
+    signInAs(HOST);
+    const entries = [makeEntry(1), makeEntry(2)];
+    mockDb.getSessionById.mockResolvedValue({
+      id: SESSION_ID,
+      host_id: HOST_USER_ID,
+      class_id_uuid: randomUUID()
+    });
+    mockDb.getQueueBySessionId.mockResolvedValue(entries);
+
+    const res = await request(app)
+      .get(`/api/sessions/${SESSION_ID}/queue`)
+      .set("Authorization", "Bearer host-token");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(2);
+    expect(mockDb.getQueueBySessionId).toHaveBeenCalledWith(SESSION_ID);
   });
 });
 

--- a/packages/express-backend/src/routes/api.js
+++ b/packages/express-backend/src/routes/api.js
@@ -195,6 +195,27 @@ async function assertClassAccess(req, res, classId) {
   return classRow;
 }
 
+async function assertSessionAccess(req, res, session) {
+  if (!session) {
+    notFoundError(res, "Session");
+    return false;
+  }
+
+  // Hosts should always be able to manage/view their own session queue,
+  // even if the linked class row was deleted or became inconsistent.
+  if (String(session.host_id) === String(req.user.id)) {
+    return true;
+  }
+
+  if (session.class_id_uuid) {
+    const classRow = await assertClassAccess(req, res, session.class_id_uuid);
+    return Boolean(classRow);
+  }
+
+  forbiddenError(res);
+  return false;
+}
+
 router.get("/classes/:classId/sessions", requireAuth, async (req, res) => {
   try {
     const classIdError = validateUuid(req.params.classId, "classId");
@@ -712,11 +733,8 @@ router.get("/sessions/:sessionId/queue", requireAuth, async (req, res) => {
     }
 
     const session = await db.getSessionById(req.params.sessionId);
-    if (!session) return notFoundError(res, "Session");
-    if (session.class_id_uuid) {
-      const classRow = await assertClassAccess(req, res, session.class_id_uuid);
-      if (!classRow) return;
-    }
+    const allowed = await assertSessionAccess(req, res, session);
+    if (!allowed) return;
 
     const queue = await db.getQueueBySessionId(req.params.sessionId);
     res.json(queue);
@@ -819,11 +837,8 @@ router.get("/sessions/:sessionId/stats", requireAuth, async (req, res) => {
     }
 
     const session = await db.getSessionById(req.params.sessionId);
-    if (!session) return notFoundError(res, "Session");
-    if (session.class_id_uuid) {
-      const classRow = await assertClassAccess(req, res, session.class_id_uuid);
-      if (!classRow) return;
-    }
+    const allowed = await assertSessionAccess(req, res, session);
+    if (!allowed) return;
 
     const stats = await db.getQueueStats(req.params.sessionId);
     res.json(stats);


### PR DESCRIPTION
- host-owned session queue/stats endpoints no longer fail just because the linked class row is missing
- added a regression test for that case